### PR TITLE
WIP: fix deprecation warnings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.3
+Compat

--- a/src/GeoInterface.jl
+++ b/src/GeoInterface.jl
@@ -1,5 +1,7 @@
 module GeoInterface
 
+    using Compat
+
     export  AbstractPosition, Position,
             AbstractGeometry, AbstractGeometryCollection, GeometryCollection,
             AbstractPoint, Point,

--- a/src/geotypes.jl
+++ b/src/geotypes.jl
@@ -1,7 +1,7 @@
 # Coordinate Reference System Objects
 # (has keys "type" and "properties")
 # TODO: Handle full CRS spec
-typealias CRS Dict{String,Any}
+typealias CRS Dict{@compat(AbstractString),Any}
 
 # Bounding Boxes
 # The value of the bbox member must be a 2*n array,
@@ -124,11 +124,11 @@ end
 geometries(collection::GeometryCollection) = collection.geometries
 
 type Feature <: AbstractFeature
-    geometry::Union(Nothing, AbstractGeometry)
-    properties::Union(Nothing, Dict{String,Any})
+    geometry::@compat(Union{Void, AbstractGeometry})
+    properties::@compat(Union{Void, Dict{@compat(AbstractString),Any}})
 end
-Feature(geometry::Union(Nothing,GeoInterface.AbstractGeometry)) = Feature(geometry, Dict{String,Any}())
-Feature(properties::Dict{String,Any}) = Feature(nothing, properties)
+Feature(geometry::@compat(Union{Void,GeoInterface.AbstractGeometry})) = Feature(geometry, Dict{@compat(AbstractString),Any}())
+Feature(properties::Dict{@compat(AbstractString),Any}) = Feature(nothing, properties)
 geometry(feature::Feature) = feature.geometry
 properties(feature::Feature) = feature.properties
 bbox(feature::Feature) = get(feature.properties, "bbox", nothing)
@@ -136,8 +136,8 @@ crs(feature::Feature) = get(feature.properties, "crs", nothing)
 
 type FeatureCollection{T <: AbstractFeature} <: AbstractFeatureCollection
     features::Vector{T}
-    bbox::Union(Nothing, BBox)
-    crs::Union(Nothing, CRS)
+    bbox::@compat(Union{Void, BBox})
+    crs::@compat(Union{Void, CRS})
 end
 FeatureCollection{T <: AbstractFeature}(fc::Vector{T}) = FeatureCollection(fc, nothing, nothing)
 features(fc::FeatureCollection) = fc.features


### PR DESCRIPTION
I can't seem to get the `Union{..}` stuff to work

```julia
  | | |_| | | | (_| |  |  Version 0.3.11 (2015-07-27 06:18 UTC)
 _/ |\__'_|_|_|\__'_|  |  Official http://julialang.org/ release
|__/                   |  x86_64-apple-darwin13.4.0

julia> using Compat

julia> @compat(Union{Int,Float64})
ERROR: type: instantiate_type: expected TypeConstructor, got Function
```