### PR TITLE
drop julia 0.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ Represents a collection of geometries, and requires the `geometries` method, whi
 Represents a geometry with additional attributes, and requires the following methods
 
 - `geometry(::AbstractFeature)::AbstractGeometry` returns the corresponding geometry
-- `properties(::AbstractFeature)::Dict{String,Any}` returns a dictionary of the properties
+- `properties(::AbstractFeature)::Dict{AbstractString,Any}` returns a dictionary of the properties
 
 Optionally, you can also provide the following methods
 
 - `bbox(::AbstractFeature)::AbstractGeometry` returns the bounding box for that feature
-- `crs(::AbstractFeature)::Dict{String,Any}` returns the coordinate reference system
+- `crs(::AbstractFeature)::Dict{AbstractString,Any}` returns the coordinate reference system
 
 ## Geospatial Geometries
 If you don't need to provide your own user types, GeoInterface also provides a set of geometries (below), which implements the GEO Interface:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3
-Compat
+julia 0.4
+Compat 0.8

--- a/src/geotypes.jl
+++ b/src/geotypes.jl
@@ -1,7 +1,7 @@
 # Coordinate Reference System Objects
 # (has keys "type" and "properties")
 # TODO: Handle full CRS spec
-typealias CRS Dict{@compat(AbstractString),Any}
+typealias CRS Dict{AbstractString,Any}
 
 # Bounding Boxes
 # The value of the bbox member must be a 2*n array,
@@ -124,11 +124,11 @@ end
 geometries(collection::GeometryCollection) = collection.geometries
 
 type Feature <: AbstractFeature
-    geometry::@compat(Union{Void, AbstractGeometry})
-    properties::@compat(Union{Void, Dict{@compat(AbstractString),Any}})
+    geometry::Union{Void, AbstractGeometry}
+    properties::Union{Void, Dict{AbstractString,Any}}
 end
-Feature(geometry::@compat(Union{Void,GeoInterface.AbstractGeometry})) = Feature(geometry, Dict{@compat(AbstractString),Any}())
-Feature(properties::Dict{@compat(AbstractString),Any}) = Feature(nothing, properties)
+Feature(geometry::Union{Void,GeoInterface.AbstractGeometry}) = Feature(geometry, Dict{AbstractString,Any}())
+Feature(properties::Dict{AbstractString,Any}) = Feature(nothing, properties)
 geometry(feature::Feature) = feature.geometry
 properties(feature::Feature) = feature.properties
 bbox(feature::Feature) = get(feature.properties, "bbox", nothing)
@@ -136,11 +136,10 @@ crs(feature::Feature) = get(feature.properties, "crs", nothing)
 
 type FeatureCollection{T <: AbstractFeature} <: AbstractFeatureCollection
     features::Vector{T}
-    bbox::@compat(Union{Void, BBox})
-    crs::@compat(Union{Void, CRS})
+    bbox::Union{Void, BBox}
+    crs::Union{Void, CRS}
 end
 FeatureCollection{T <: AbstractFeature}(fc::Vector{T}) = FeatureCollection(fc, nothing, nothing)
 features(fc::FeatureCollection) = fc.features
 bbox(fc::FeatureCollection) = fc.bbox
 crs(fc::FeatureCollection) = fc.crs
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,1 @@
+using GeoInterface


### PR DESCRIPTION
I think after merging this I'll tag a new version. The current release is quite old and uses `Nothing`, which was deprecated in v0.4, and is gone in v0.5.

Are there any other things that should still be done before tagging a new version?