### PR TITLE
Add support for integration into Plots ecosystem

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+RecipesBase

--- a/src/GeoInterface.jl
+++ b/src/GeoInterface.jl
@@ -2,6 +2,8 @@ __precompile__()
 
 module GeoInterface
 
+    import RecipesBase
+
     export  AbstractPosition, Position,
             AbstractGeometry, AbstractGeometryCollection, GeometryCollection,
             AbstractPoint, Point,
@@ -79,4 +81,5 @@ module GeoInterface
     crs(obj::AbstractFeatureCollection) = nothing
 
     include("geotypes.jl")
+    include("plotrecipes.jl")
 end

--- a/src/GeoInterface.jl
+++ b/src/GeoInterface.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module GeoInterface
 
-    import RecipesBase
+    using RecipesBase
 
     export  AbstractPosition, Position,
             AbstractGeometry, AbstractGeometryCollection, GeometryCollection,

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -1,13 +1,25 @@
 shapecoords(geom::AbstractPoint) = [tuple(coordinates(geom)...)]
-RecipesBase.@recipe f(geom::AbstractPoint) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
+RecipesBase.@recipe f(geom::AbstractPoint) = (
+    aspect_ratio := 1;
+    seriestype --> :scatter;
+    legend --> :false;
+    shapecoords(geom)
+)
 
-shapecoords(geom::AbstractVector{<:AbstractPoint}) = Tuple{Float64,Float64}[tuple(coordinates(g)...) for g in geom]
+shapecoords(geom::AbstractVector{<:AbstractPoint}) = Tuple{Float64,Float64}[
+    tuple(coordinates(g)...) for g in geom
+]
 
 function shapecoords(geom::AbstractMultiPoint)
     coords = coordinates(geom)
     first.(coords), last.(coords)
 end
-RecipesBase.@recipe f(geom::AbstractMultiPoint) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
+RecipesBase.@recipe f(geom::AbstractMultiPoint) = (
+    aspect_ratio := 1;
+    seriestype --> :scatter;
+    legend --> :false;
+    shapecoords(geom)
+)
 
 function shapecoords(geom::Vector{<:AbstractMultiPoint})
     x = Float64[]; y = Float64[]
@@ -22,7 +34,12 @@ function shapecoords(geom::AbstractLineString)
     coords = coordinates(geom)
     first.(coords), last.(coords)
 end
-RecipesBase.@recipe f(geom::AbstractLineString) = (seriestype --> :line; legend --> :false; shapecoords(geom))
+RecipesBase.@recipe f(geom::AbstractLineString) = (
+    aspect_ratio := 1;
+    seriestype --> :path;
+    legend --> :false;
+    shapecoords(geom)
+)
 
 function shapecoords(geom::Vector{<:AbstractLineString})
     x = Vector{Float64}[]; y = Vector{Float64}[]
@@ -39,7 +56,12 @@ function shapecoords(geom::AbstractMultiLineString)
     y = Vector{Float64}[last.(line) for line in coords]
     x, y
 end
-RecipesBase.@recipe f(geom::AbstractMultiLineString) = (seriestype --> :line; legend --> :false; shapecoords(geom))
+RecipesBase.@recipe f(geom::AbstractMultiLineString) = (
+    aspect_ratio := 1;
+    seriestype --> :path;
+    legend --> :false;
+    shapecoords(geom)
+)
 
 function shapecoords(geom::Vector{<:AbstractMultiLineString})
     x = Vector{Float64}[]; y = Vector{Float64}[]
@@ -53,7 +75,12 @@ function shapecoords(geom::AbstractPolygon)
     ring = first(coordinates(geom)) # currently doesn't plot holes
     first.(ring), last.(ring)
 end
-RecipesBase.@recipe f(geom::AbstractPolygon) = (seriestype --> :shape; legend --> :false; shapecoords(geom))
+RecipesBase.@recipe f(geom::AbstractPolygon) = (
+    aspect_ratio := 1;
+    seriestype --> :shape;
+    legend --> :false;
+    shapecoords(geom)
+)
 
 function shapecoords(geom::Vector{<:AbstractPolygon})
     x = Vector{Float64}[]; y = Vector{Float64}[]
@@ -72,7 +99,12 @@ function shapecoords(geom::AbstractMultiPolygon)
     end
     x, y
 end
-RecipesBase.@recipe f(geom::AbstractMultiPolygon) = (seriestype --> :shape; legend --> :false; shapecoords(geom))
+RecipesBase.@recipe f(geom::AbstractMultiPolygon) = (
+    aspect_ratio := 1;
+    seriestype --> :shape;
+    legend --> :false;
+    shapecoords(geom)
+)
 
 function shapecoords(geom::Vector{<:AbstractMultiPolygon})
     x, y = Vector{Float64}[], Vector{Float64}[]
@@ -84,13 +116,14 @@ function shapecoords(geom::Vector{<:AbstractMultiPolygon})
 end
 
 RecipesBase.@recipe function f(geom::Vector{<:AbstractGeometry})
+    aspect_ratio := 1
     legend --> :false
     for g in geom
         @series begin
             if g isa AbstractPoint || g isa AbstractMultiPoint
                 seriestype := :scatter
             elseif g isa AbstractLineString || g isa AbstractMultiLineString
-                seriestype := :line
+                seriestype := :path
             elseif g isa AbstractPolygon || g isa AbstractMultiPolygon
                 seriestype := :shape
             end

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -27,9 +27,9 @@ RecipesBase.@recipe f(geom::AbstractMultiPoint) = (
 
 function shapecoords(geom::Vector{<:AbstractMultiPoint})
     x = Float64[]; y = Float64[]
-    for g in geom
-        coords = coordinates(g)
-        append!(x, first.(coords)); append!(y, last.(coords))
+    for g in geom, pt in coordinates(g)
+        push!(x, pt[1]); push!(x, NaN)
+        push!(y, pt[2]); push!(y, NaN)
     end
     x, y
 end
@@ -55,9 +55,8 @@ function shapecoords(geom::Vector{<:AbstractLineString})
 end
 
 function shapecoords(geom::AbstractMultiLineString)
-    coords = coordinates(geom)
     x, y = Float64[], Float64[]
-    for line in coords
+    for line in coordinates(geom)
         append!(x, first.(line)); push!(x, NaN)
         append!(y, last.(line)); push!(y, NaN)
     end
@@ -71,9 +70,10 @@ RecipesBase.@recipe f(geom::AbstractMultiLineString) = (
 )
 
 function shapecoords(geom::Vector{<:AbstractMultiLineString})
-    x = Vector{Float64}[]; y = Vector{Float64}[]
+    x = Float64[]; y = Float64[]
     for g in geom, line in coordinates(g)
-        push!(x, first.(line)); push!(y, last.(line))
+        append!(x, first.(line)); push!(x, NaN)
+        append!(y, last.(line)); push!(y, NaN)
     end
     x, y
 end
@@ -115,10 +115,11 @@ RecipesBase.@recipe f(geom::AbstractMultiPolygon) = (
 )
 
 function shapecoords(geom::Vector{<:AbstractMultiPolygon})
-    x, y = Vector{Float64}[], Vector{Float64}[]
+    x, y = Float64[], Float64[]
     for g in geom, poly in coordinates(g)
         ring = first(coordinates(poly)) # currently doesn't plot holes
-        push!(x, first.(ring)); push!(y, last.(ring))
+        append!(x, first.(ring)); push!(x, NaN)
+        append!(y, last.(ring)); push!(y, NaN)
     end
     x, y
 end

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -1,8 +1,8 @@
 shapecoords(geom::AbstractPoint) = [tuple(coordinates(geom)...)]
 RecipesBase.@recipe f(geom::AbstractPoint) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
 
-shapecoords{T <: AbstractPoint}(geom::AbstractVector{T}) = Tuple{Float64,Float64}[tuple(coordinates(g)...) for g in geom]
-RecipesBase.@recipe f{T <: AbstractPoint}(geom::AbstractVector{T}) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
+shapecoords(geom::AbstractVector{<:AbstractPoint}) = Tuple{Float64,Float64}[tuple(coordinates(g)...) for g in geom]
+RecipesBase.@recipe f(geom::AbstractVector{<:AbstractPoint}) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractMultiPoint)
     coords = coordinates(geom)
@@ -10,7 +10,7 @@ function shapecoords(geom::AbstractMultiPoint)
 end
 RecipesBase.@recipe f(geom::AbstractMultiPoint) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
 
-function shapecoords{T <: AbstractMultiPoint}(geom::Vector{T})
+function shapecoords(geom::Vector{<:AbstractMultiPoint})
     x = Float64[]; y = Float64[]
     for g in geom
         coords = coordinates(g)
@@ -18,7 +18,7 @@ function shapecoords{T <: AbstractMultiPoint}(geom::Vector{T})
     end
     x, y
 end
-RecipesBase.@recipe f{T <: AbstractMultiPoint}(geom::Vector{T}) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
+RecipesBase.@recipe f(geom::Vector{<:AbstractMultiPoint}) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractLineString)
     coords = coordinates(geom)
@@ -26,7 +26,7 @@ function shapecoords(geom::AbstractLineString)
 end
 RecipesBase.@recipe f(geom::AbstractLineString) = (seriestype --> :line; legend --> :false; shapecoords(geom))
 
-function shapecoords{T <: AbstractLineString}(geom::Vector{T})
+function shapecoords(geom::Vector{<:AbstractLineString})
     x = Vector{Float64}[]; y = Vector{Float64}[]
     for line in geom
         coords = coordinates(geom)
@@ -34,7 +34,7 @@ function shapecoords{T <: AbstractLineString}(geom::Vector{T})
     end
     x, y
 end
-RecipesBase.@recipe f{T <: AbstractLineString}(geom::Vector{T}) = (seriestype --> :line; legend --> :false; shapecoords(geom))
+RecipesBase.@recipe f(geom::Vector{<:AbstractLineString}) = (seriestype --> :line; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractMultiLineString)
     coords = coordinates(geom)
@@ -44,14 +44,14 @@ function shapecoords(geom::AbstractMultiLineString)
 end
 RecipesBase.@recipe f(geom::AbstractMultiLineString) = (seriestype --> :line; legend --> :false; shapecoords(geom))
 
-function shapecoords{T <: AbstractMultiLineString}(geom::Vector{T})
+function shapecoords(geom::Vector{<:AbstractMultiLineString})
     x = Vector{Float64}[]; y = Vector{Float64}[]
     for g in geom, line in coordinates(g)
         push!(x, first.(line)); push!(y, last.(line))
     end
     x, y
 end
-RecipesBase.@recipe f{T <: AbstractMultiLineString}(geom::Vector{T}) = (seriestype --> :line; legend --> :false; shapecoords(geom))
+RecipesBase.@recipe f(geom::Vector{<:AbstractMultiLineString}) = (seriestype --> :line; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractPolygon)
     ring = first(coordinates(geom)) # currently doesn't plot holes
@@ -59,7 +59,7 @@ function shapecoords(geom::AbstractPolygon)
 end
 RecipesBase.@recipe f(geom::AbstractPolygon) = (seriestype --> :shape; legend --> :false; shapecoords(geom))
 
-function shapecoords{T <: AbstractPolygon}(geom::Vector{T})
+function shapecoords(geom::Vector{<:AbstractPolygon})
     x = Vector{Float64}[]; y = Vector{Float64}[]
     for g in geom
         ring = first(coordinates(g)) # currently doesn't plot holes
@@ -67,7 +67,7 @@ function shapecoords{T <: AbstractPolygon}(geom::Vector{T})
     end
     x, y
 end
-RecipesBase.@recipe f{T <: AbstractPolygon}(geom::Vector{T}) = (seriestype --> :shape; legend --> :false; shapecoords(geom))
+RecipesBase.@recipe f(geom::Vector{<:AbstractPolygon}) = (seriestype --> :shape; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractMultiPolygon)
     x, y = Vector{Float64}[], Vector{Float64}[]
@@ -79,7 +79,7 @@ function shapecoords(geom::AbstractMultiPolygon)
 end
 RecipesBase.@recipe f(geom::AbstractMultiPolygon) = (seriestype --> :shape; legend --> :false; shapecoords(geom))
 
-function shapecoords{T <: AbstractMultiPolygon}(geom::Vector{T})
+function shapecoords(geom::Vector{<:AbstractMultiPolygon})
     x, y = Vector{Float64}[], Vector{Float64}[]
     for g in geom, poly in coordinates(g)
         ring = first(coordinates(poly)) # currently doesn't plot holes
@@ -87,4 +87,4 @@ function shapecoords{T <: AbstractMultiPolygon}(geom::Vector{T})
     end
     x, y
 end
-RecipesBase.@recipe f{T <: AbstractMultiPolygon}(geom::Vector{T}) = (seriestype --> :shape; legend --> :false; shapecoords(geom))
+RecipesBase.@recipe f(geom::Vector{<:AbstractMultiPolygon}) = (seriestype --> :shape; legend --> :false; shapecoords(geom))

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -2,53 +2,35 @@ shapecoords(geom::AbstractPoint) = [tuple(coordinates(geom)...)]
 RecipesBase.@recipe f(geom::AbstractPoint) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractMultiPoint)
-    x, y = [], []
-    for (xi,yi) in coordinates(geom)
-        push!(x, xi); push!(y, yi)
-    end
-    x, y
+    coords = coordinates(geom)
+    first.(coordinates(geom)), last.(coordinates(geom))
 end
 RecipesBase.@recipe f(geom::AbstractMultiPoint) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractLineString)
-    x, y = [], []
-    for (xi,yi) in coordinates(geom)
-        push!(x, xi); push!(y, yi)
-    end
-    x, y
+    coords = coordinates(geom)
+    first.(coordinates(geom)), last.(coordinates(geom))
 end
 RecipesBase.@recipe f(geom::AbstractLineString) = (seriestype --> :line; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractMultiLineString)
-    x, y = [], []
-    for line in coordinates(geom)
-        linex, liney = [], []
-        for (xi,yi) in line
-            push!(linex, xi); push!(liney, yi)
-        end
-        push!(x, linex); push!(y, liney)
-    end
+    x = Vector{Float64}[first.(line) for line in coordinates(geom)]
+    y = Vector{Float64}[last.(line) for line in coordinates(geom)]
     x, y
 end
 RecipesBase.@recipe f(geom::AbstractMultiLineString) = (seriestype --> :line; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractPolygon)
-    x, y = [], []
-    for (xi,yi) in first(coordinates(geom))
-        push!(x, xi); push!(y, yi)
-    end
-    x, y
+    ring = first(coordinates(geom)) # currently doesn't plot holes
+    first.(ring), last.(ring)
 end
 RecipesBase.@recipe f(geom::AbstractPolygon) = (seriestype --> :shape; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractMultiPolygon)
-    x, y = [], []
+    x, y = Vector{Float64}[], Vector{Float64}[]
     for poly in coordinates(geom)
-        ringx, ringy = [], []
-        for (xi,yi) in first(poly)
-            push!(ringx, xi); push!(ringy, yi)
-        end
-        push!(x, ringx); push!(y, ringy)
+        ring = first(coordinates(poly)) # currently doesn't plot holes
+        push!(x, first.(ring)); push!(y, last.(ring))
     end
     x, y
 end

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -12,6 +12,11 @@ shapecoords(geom::AbstractVector{<:AbstractPoint}) = Tuple{Float64,Float64}[
 
 function shapecoords(geom::AbstractMultiPoint)
     coords = coordinates(geom)
+    x, y = Float64[], Float64[]
+    for pt in coords
+        push!(x, pt[1]); push!(x, NaN)
+        append!(y, pt[2]); push!(y, NaN)
+    end
     first.(coords), last.(coords)
 end
 RecipesBase.@recipe f(geom::AbstractMultiPoint) = (
@@ -52,8 +57,11 @@ end
 
 function shapecoords(geom::AbstractMultiLineString)
     coords = coordinates(geom)
-    x = Vector{Float64}[first.(line) for line in coords]
-    y = Vector{Float64}[last.(line) for line in coords]
+    x, y = Float64[], Float64[]
+    for line in coords
+        append!(x, first.(line)); push!(x, NaN)
+        append!(y, last.(line)); push!(y, NaN)
+    end
     x, y
 end
 RecipesBase.@recipe f(geom::AbstractMultiLineString) = (
@@ -92,10 +100,11 @@ function shapecoords(geom::Vector{<:AbstractPolygon})
 end
 
 function shapecoords(geom::AbstractMultiPolygon)
-    x, y = Vector{Float64}[], Vector{Float64}[]
+    x, y = Float64[], Float64[]
     for poly in coordinates(geom)
         ring = first(coordinates(poly)) # currently doesn't plot holes
-        push!(x, first.(ring)); push!(y, last.(ring))
+        append!(x, first.(ring)); push!(x, NaN)
+        append!(y, last.(ring)); push!(y, NaN)
     end
     x, y
 end

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -1,0 +1,55 @@
+shapecoords(geom::AbstractPoint) = [tuple(coordinates(geom)...)]
+RecipesBase.@recipe f(geom::AbstractPoint) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
+
+function shapecoords(geom::AbstractMultiPoint)
+    x, y = [], []
+    for (xi,yi) in coordinates(geom)
+        push!(x, xi); push!(y, yi)
+    end
+    x, y
+end
+RecipesBase.@recipe f(geom::AbstractMultiPoint) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
+
+function shapecoords(geom::AbstractLineString)
+    x, y = [], []
+    for (xi,yi) in coordinates(geom)
+        push!(x, xi); push!(y, yi)
+    end
+    x, y
+end
+RecipesBase.@recipe f(geom::AbstractLineString) = (seriestype --> :line; legend --> :false; shapecoords(geom))
+
+function shapecoords(geom::AbstractMultiLineString)
+    x, y = [], []
+    for line in coordinates(geom)
+        linex, liney = [], []
+        for (xi,yi) in line
+            push!(linex, xi); push!(liney, yi)
+        end
+        push!(x, linex); push!(y, liney)
+    end
+    x, y
+end
+RecipesBase.@recipe f(geom::AbstractMultiLineString) = (seriestype --> :line; legend --> :false; shapecoords(geom))
+
+function shapecoords(geom::AbstractPolygon)
+    x, y = [], []
+    for (xi,yi) in first(coordinates(geom))
+        push!(x, xi); push!(y, yi)
+    end
+    x, y
+end
+RecipesBase.@recipe f(geom::AbstractPolygon) = (seriestype --> :shape; legend --> :false; shapecoords(geom))
+
+function shapecoords(geom::AbstractMultiPolygon)
+    x, y = [], []
+    for poly in coordinates(geom)
+        ringx, ringy = [], []
+        for (xi,yi) in first(poly)
+            push!(ringx, xi); push!(ringy, yi)
+        end
+        push!(x, ringx); push!(y, ringy)
+    end
+    x, y
+end
+RecipesBase.@recipe f(geom::AbstractMultiPolygon) = (seriestype --> :shape; legend --> :false; shapecoords(geom))

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -1,17 +1,40 @@
 shapecoords(geom::AbstractPoint) = [tuple(coordinates(geom)...)]
 RecipesBase.@recipe f(geom::AbstractPoint) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
 
+shapecoords{T <: AbstractPoint}(geom::AbstractVector{T}) = Tuple{Float64,Float64}[tuple(coordinates(g)...) for g in geom]
+RecipesBase.@recipe f{T <: AbstractPoint}(geom::AbstractVector{T}) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
+
 function shapecoords(geom::AbstractMultiPoint)
     coords = coordinates(geom)
     first.(coords), last.(coords)
 end
 RecipesBase.@recipe f(geom::AbstractMultiPoint) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
 
+function shapecoords{T <: AbstractMultiPoint}(geom::Vector{T})
+    x = Float64[]; y = Float64[]
+    for g in geom
+        coords = coordinates(g)
+        append!(x, first.(coords)); append!(y, last.(coords))
+    end
+    x, y
+end
+RecipesBase.@recipe f{T <: AbstractMultiPoint}(geom::Vector{T}) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
+
 function shapecoords(geom::AbstractLineString)
     coords = coordinates(geom)
     first.(coords), last.(coords)
 end
 RecipesBase.@recipe f(geom::AbstractLineString) = (seriestype --> :line; legend --> :false; shapecoords(geom))
+
+function shapecoords{T <: AbstractLineString}(geom::Vector{T})
+    x = Vector{Float64}[]; y = Vector{Float64}[]
+    for line in geom
+        coords = coordinates(geom)
+        push!(x, first.(coords)); push!(y, last.(coords))
+    end
+    x, y
+end
+RecipesBase.@recipe f{T <: AbstractLineString}(geom::Vector{T}) = (seriestype --> :line; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractMultiLineString)
     coords = coordinates(geom)
@@ -21,11 +44,30 @@ function shapecoords(geom::AbstractMultiLineString)
 end
 RecipesBase.@recipe f(geom::AbstractMultiLineString) = (seriestype --> :line; legend --> :false; shapecoords(geom))
 
+function shapecoords{T <: AbstractMultiLineString}(geom::Vector{T})
+    x = Vector{Float64}[]; y = Vector{Float64}[]
+    for g in geom, line in coordinates(g)
+        push!(x, first.(line)); push!(y, last.(line))
+    end
+    x, y
+end
+RecipesBase.@recipe f{T <: AbstractMultiLineString}(geom::Vector{T}) = (seriestype --> :line; legend --> :false; shapecoords(geom))
+
 function shapecoords(geom::AbstractPolygon)
     ring = first(coordinates(geom)) # currently doesn't plot holes
     first.(ring), last.(ring)
 end
 RecipesBase.@recipe f(geom::AbstractPolygon) = (seriestype --> :shape; legend --> :false; shapecoords(geom))
+
+function shapecoords{T <: AbstractPolygon}(geom::Vector{T})
+    x = Vector{Float64}[]; y = Vector{Float64}[]
+    for g in geom
+        ring = first(coordinates(geom)) # currently doesn't plot holes
+        push!(x, first.(ring)); push!(y, last.(ring))
+    end
+    x, y
+end
+RecipesBase.@recipe f{T <: AbstractPolygon}(geom::Vector{T}) = (seriestype --> :shape; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractMultiPolygon)
     x, y = Vector{Float64}[], Vector{Float64}[]
@@ -36,3 +78,13 @@ function shapecoords(geom::AbstractMultiPolygon)
     x, y
 end
 RecipesBase.@recipe f(geom::AbstractMultiPolygon) = (seriestype --> :shape; legend --> :false; shapecoords(geom))
+
+function shapecoords{T <: AbstractMultiPolygon}(geom::Vector{T})
+    x, y = Vector{Float64}[], Vector{Float64}[]
+    for g in geom, poly in coordinates(g)
+        ring = first(coordinates(poly)) # currently doesn't plot holes
+        push!(x, first.(ring)); push!(y, last.(ring))
+    end
+    x, y
+end
+RecipesBase.@recipe f{T <: AbstractMultiPolygon}(geom::Vector{T}) = (seriestype --> :shape; legend --> :false; shapecoords(geom))

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -3,19 +3,20 @@ RecipesBase.@recipe f(geom::AbstractPoint) = (seriestype --> :scatter; legend --
 
 function shapecoords(geom::AbstractMultiPoint)
     coords = coordinates(geom)
-    first.(coordinates(geom)), last.(coordinates(geom))
+    first.(coords), last.(coords)
 end
 RecipesBase.@recipe f(geom::AbstractMultiPoint) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractLineString)
     coords = coordinates(geom)
-    first.(coordinates(geom)), last.(coordinates(geom))
+    first.(coords), last.(coords)
 end
 RecipesBase.@recipe f(geom::AbstractLineString) = (seriestype --> :line; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractMultiLineString)
-    x = Vector{Float64}[first.(line) for line in coordinates(geom)]
-    y = Vector{Float64}[last.(line) for line in coordinates(geom)]
+    coords = coordinates(geom)
+    x = Vector{Float64}[first.(line) for line in coords]
+    y = Vector{Float64}[last.(line) for line in coords]
     x, y
 end
 RecipesBase.@recipe f(geom::AbstractMultiLineString) = (seriestype --> :line; legend --> :false; shapecoords(geom))

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -17,7 +17,7 @@ function shapecoords(geom::AbstractMultiPoint)
         push!(x, pt[1]); push!(x, NaN)
         append!(y, pt[2]); push!(y, NaN)
     end
-    first.(coords), last.(coords)
+    x, y
 end
 RecipesBase.@recipe f(geom::AbstractMultiPoint) = (
     aspect_ratio := 1;

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -11,11 +11,10 @@ shapecoords(geom::AbstractVector{<:AbstractPoint}) = Tuple{Float64,Float64}[
 ]
 
 function shapecoords(geom::AbstractMultiPoint)
-    coords = coordinates(geom)
     x, y = Float64[], Float64[]
-    for pt in coords
+    for pt in coordinates(geom)
         push!(x, pt[1]); push!(x, NaN)
-        append!(y, pt[2]); push!(y, NaN)
+        push!(y, pt[2]); push!(y, NaN)
     end
     x, y
 end

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -2,7 +2,6 @@ shapecoords(geom::AbstractPoint) = [tuple(coordinates(geom)...)]
 RecipesBase.@recipe f(geom::AbstractPoint) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
 
 shapecoords(geom::AbstractVector{<:AbstractPoint}) = Tuple{Float64,Float64}[tuple(coordinates(g)...) for g in geom]
-RecipesBase.@recipe f(geom::AbstractVector{<:AbstractPoint}) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractMultiPoint)
     coords = coordinates(geom)
@@ -18,7 +17,6 @@ function shapecoords(geom::Vector{<:AbstractMultiPoint})
     end
     x, y
 end
-RecipesBase.@recipe f(geom::Vector{<:AbstractMultiPoint}) = (seriestype --> :scatter; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractLineString)
     coords = coordinates(geom)
@@ -34,7 +32,6 @@ function shapecoords(geom::Vector{<:AbstractLineString})
     end
     x, y
 end
-RecipesBase.@recipe f(geom::Vector{<:AbstractLineString}) = (seriestype --> :line; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractMultiLineString)
     coords = coordinates(geom)
@@ -51,7 +48,6 @@ function shapecoords(geom::Vector{<:AbstractMultiLineString})
     end
     x, y
 end
-RecipesBase.@recipe f(geom::Vector{<:AbstractMultiLineString}) = (seriestype --> :line; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractPolygon)
     ring = first(coordinates(geom)) # currently doesn't plot holes
@@ -67,7 +63,6 @@ function shapecoords(geom::Vector{<:AbstractPolygon})
     end
     x, y
 end
-RecipesBase.@recipe f(geom::Vector{<:AbstractPolygon}) = (seriestype --> :shape; legend --> :false; shapecoords(geom))
 
 function shapecoords(geom::AbstractMultiPolygon)
     x, y = Vector{Float64}[], Vector{Float64}[]
@@ -87,4 +82,24 @@ function shapecoords(geom::Vector{<:AbstractMultiPolygon})
     end
     x, y
 end
-RecipesBase.@recipe f(geom::Vector{<:AbstractMultiPolygon}) = (seriestype --> :shape; legend --> :false; shapecoords(geom))
+
+RecipesBase.@recipe function f(geom::Vector{<:AbstractGeometry})
+    legend --> :false
+    for g in geom
+        @series begin
+            if g isa AbstractPoint || g isa AbstractMultiPoint
+                seriestype := :scatter
+            elseif g isa AbstractLineString || g isa AbstractMultiLineString
+                seriestype := :line
+            elseif g isa AbstractPolygon || g isa AbstractMultiPolygon
+                seriestype := :shape
+            end
+            shapecoords(g)
+        end
+    end
+end
+
+RecipesBase.@recipe f(feature::AbstractFeature) = geometry(feature)
+RecipesBase.@recipe f(features::Vector{<:AbstractFeature}) = geometry.(features)
+RecipesBase.@recipe f(collection::AbstractFeatureCollection) = features(collection)
+RecipesBase.@recipe f(collection::AbstractGeometryCollection) = geometries(collection)

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -62,7 +62,7 @@ RecipesBase.@recipe f(geom::AbstractPolygon) = (seriestype --> :shape; legend --
 function shapecoords{T <: AbstractPolygon}(geom::Vector{T})
     x = Vector{Float64}[]; y = Vector{Float64}[]
     for g in geom
-        ring = first(coordinates(geom)) # currently doesn't plot holes
+        ring = first(coordinates(g)) # currently doesn't plot holes
         push!(x, first.(ring)); push!(y, last.(ring))
     end
     x, y


### PR DESCRIPTION
@visr @mkborregaard

Based on the discussion in https://github.com/JuliaGeo/Shapefile.jl/issues/12

So the example in the README of PlotRecipes.jl will now be:

```julia
using Plots, Shapefile
dir = "https://github.com/nvkelso/natural-earth-vector/raw/master/110m_physical/"
fn = "ne_110m_land.shp"
run(`wget $dir/$fn -P /tmp/`)
shp = open("/tmp/$fn") do fd
    read(fd, Shapefile.Handle)
end
plt = plot()
for s in shp.shapes; plot!(plt, s); end
plt
```
and yield
![example](https://user-images.githubusercontent.com/1231079/34464171-ced53282-ee42-11e7-8c8d-db88e18b7951.png)

Suggestions/improvements welcome!
