### PR TITLE
Remove unused `shapecoords()` methods

### DIFF
--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -6,17 +6,9 @@ RecipesBase.@recipe f(geom::AbstractPoint) = (
     shapecoords(geom)
 )
 
-shapecoords(geom::AbstractVector{<:AbstractPoint}) = Tuple{Float64,Float64}[
-    tuple(coordinates(g)...) for g in geom
-]
-
 function shapecoords(geom::AbstractMultiPoint)
-    x, y = Float64[], Float64[]
-    for pt in coordinates(geom)
-        push!(x, pt[1]); push!(x, NaN)
-        push!(y, pt[2]); push!(y, NaN)
-    end
-    x, y
+    coords = coordinates(geom)
+    first.(coords), last.(coords)
 end
 RecipesBase.@recipe f(geom::AbstractMultiPoint) = (
     aspect_ratio := 1;
@@ -24,15 +16,6 @@ RecipesBase.@recipe f(geom::AbstractMultiPoint) = (
     legend --> :false;
     shapecoords(geom)
 )
-
-function shapecoords(geom::Vector{<:AbstractMultiPoint})
-    x = Float64[]; y = Float64[]
-    for g in geom, pt in coordinates(g)
-        push!(x, pt[1]); push!(x, NaN)
-        push!(y, pt[2]); push!(y, NaN)
-    end
-    x, y
-end
 
 function shapecoords(geom::AbstractLineString)
     coords = coordinates(geom)
@@ -44,15 +27,6 @@ RecipesBase.@recipe f(geom::AbstractLineString) = (
     legend --> :false;
     shapecoords(geom)
 )
-
-function shapecoords(geom::Vector{<:AbstractLineString})
-    x = Vector{Float64}[]; y = Vector{Float64}[]
-    for line in geom
-        coords = coordinates(geom)
-        push!(x, first.(coords)); push!(y, last.(coords))
-    end
-    x, y
-end
 
 function shapecoords(geom::AbstractMultiLineString)
     x, y = Float64[], Float64[]
@@ -69,15 +43,6 @@ RecipesBase.@recipe f(geom::AbstractMultiLineString) = (
     shapecoords(geom)
 )
 
-function shapecoords(geom::Vector{<:AbstractMultiLineString})
-    x = Float64[]; y = Float64[]
-    for g in geom, line in coordinates(g)
-        append!(x, first.(line)); push!(x, NaN)
-        append!(y, last.(line)); push!(y, NaN)
-    end
-    x, y
-end
-
 function shapecoords(geom::AbstractPolygon)
     ring = first(coordinates(geom)) # currently doesn't plot holes
     first.(ring), last.(ring)
@@ -88,15 +53,6 @@ RecipesBase.@recipe f(geom::AbstractPolygon) = (
     legend --> :false;
     shapecoords(geom)
 )
-
-function shapecoords(geom::Vector{<:AbstractPolygon})
-    x = Vector{Float64}[]; y = Vector{Float64}[]
-    for g in geom
-        ring = first(coordinates(g)) # currently doesn't plot holes
-        push!(x, first.(ring)); push!(y, last.(ring))
-    end
-    x, y
-end
 
 function shapecoords(geom::AbstractMultiPolygon)
     x, y = Float64[], Float64[]
@@ -113,16 +69,6 @@ RecipesBase.@recipe f(geom::AbstractMultiPolygon) = (
     legend --> :false;
     shapecoords(geom)
 )
-
-function shapecoords(geom::Vector{<:AbstractMultiPolygon})
-    x, y = Float64[], Float64[]
-    for g in geom, poly in coordinates(g)
-        ring = first(coordinates(poly)) # currently doesn't plot holes
-        append!(x, first.(ring)); push!(x, NaN)
-        append!(y, last.(ring)); push!(y, NaN)
-    end
-    x, y
-end
 
 RecipesBase.@recipe function f(geom::Vector{<:AbstractGeometry})
     aspect_ratio := 1


### PR DESCRIPTION
they were wrong (and unused anyway; since only the recipe for
`geom::Vector{<:AbstractGeometry}` is used)

Martijn, can you help me verify on

```julia
;cd ~/.julia/v0.6/Shapefile/test

using Shapefile, Plots

f(i) = plot(open("shapelib_testcases/test$i.shp") do f
    read(f, Shapefile.Handle).shapes
end, alpha=0.5)

plot([f(i) for i in 1:12]...)
```
It should give
![shapefiletests](https://user-images.githubusercontent.com/1231079/34579561-77d22734-f157-11e7-9a6d-9b2f78d78e58.png)

  