### PR TITLE
Add comparison operators for some geometry types.

### DIFF
--- a/src/GeoInterface.jl
+++ b/src/GeoInterface.jl
@@ -80,6 +80,7 @@ module GeoInterface
     bbox(obj::AbstractFeatureCollection) = nothing
     crs(obj::AbstractFeatureCollection) = nothing
 
+    include("operations.jl")
     include("geotypes.jl")
     include("plotrecipes.jl")
 end

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,7 +1,10 @@
-import Base: ==, hash
+import Base: ==, hash, isapprox
 
 # Compare points by coordinate values.
 ==(x::P, y::P) where {P <: AbstractPoint} = coordinates(x) == coordinates(y)
 
 # Hash the coordinates for consistency.
 hash(x::P) where {P <: AbstractPoint} = hash(coordinates(x))
+
+# Compare points approximately by coordinate values.
+isapprox(x::P, y::P; kwargs...) where {P <: AbstractPoint} = isapprox(coordinates(x), coordinates(y); kwargs...)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,0 +1,7 @@
+import Base: ==, hash
+
+# Compare points by coordinate values.
+==(x::P, y::P) where {P <: AbstractPoint} = coordinates(x) == coordinates(y)
+
+# Hash the coordinates for consistency.
+hash(x::P) where {P <: AbstractPoint} = hash(coordinates(x))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,1 +1,30 @@
 using GeoInterface
+using Test
+
+@testset "Comparison operators" begin
+    # Points are now compared by value:
+    pt1, pt2, pt3 = Point([0.0, 0.0]), Point([0.0, 0.0]), Point([0.0, 1.0])
+    @test pt1 == pt1
+    @test pt1 == pt2
+    @test pt1 != pt3
+
+    # Also, the hash is based on the coordinates
+    @test hash(pt1) == hash(pt1)
+    @test hash(pt1) == hash(pt2)
+    @test hash(pt1) != hash(pt3)
+
+    # Implicitly, this should also work for `isequal`:
+    @test isequal(pt1, pt1)
+    @test isequal(pt1, pt2)
+    @test !isequal(pt1, pt3)
+
+
+    # The same is not true for other geometry types: The representation is not
+    # unique, so comparing the coordinates directly might be misleading.
+    pg1 = Polygon([[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]]])
+    pg2 = Polygon([[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]]])
+    pg3 = Polygon([[[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]]])
+    @test pg1 == pg1   # same objects
+    @test pg1 != pg2   # same values, but different objects
+    @test pg1 != pg3   # equivalent, but not same values
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,13 @@ using Test
     @test isequal(pt1, pt2)
     @test !isequal(pt1, pt3)
 
+    # Can also do approximate comparisons
+    pt4 = Point([0.0, 1.001])
+    @test pt3 != pt4
+    @test pt3 ≉ pt4  atol=0.0001
+    @test pt3 ≉ pt4  rtol=0.0001
+    @test pt3 ≈ pt4  atol=0.001
+    @test pt3 ≈ pt4  rtol=0.001
 
     # The same is not true for other geometry types: The representation is not
     # unique, so comparing the coordinates directly might be misleading.


### PR DESCRIPTION
Fixes #21.

Only implementing the uncontroversial part now, for `Point`s.