### PR TITLE
Refactor

### DIFF
--- a/src/GeoInterface.jl
+++ b/src/GeoInterface.jl
@@ -2,85 +2,28 @@ __precompile__()
 
 module GeoInterface
 
-    using RecipesBase
+using RecipesBase
 
-    export  AbstractPosition, Position,
-            AbstractGeometry, AbstractGeometryCollection, GeometryCollection,
-            AbstractPoint, Point,
-            AbstractMultiPoint, MultiPoint,
-            AbstractLineString, LineString,
-            AbstractMultiLineString, MultiLineString,
-            AbstractPolygon, Polygon,
-            AbstractMultiPolygon, MultiPolygon,
-            AbstractFeature, Feature,
-            AbstractFeatureCollection, FeatureCollection,
+export  AbstractPosition, Position,
+        AbstractGeometry, AbstractGeometryCollection, GeometryCollection,
+        AbstractPoint, Point,
+        AbstractMultiPoint, MultiPoint,
+        AbstractLineString, LineString,
+        AbstractMultiLineString, MultiLineString,
+        AbstractPolygon, Polygon,
+        AbstractMultiPolygon, MultiPolygon,
+        AbstractFeature, Feature,
+        AbstractFeatureCollection, FeatureCollection,
 
-            geotype, # methods
-            xcoord, ycoord, zcoord, hasz,
-            coordinates,
-            geometries,
-            geometry, bbox, crs, properties,
-            features
+        geotype, # methods
+        xcoord, ycoord, zcoord, hasz,
+        coordinates,
+        geometries,
+        geometry, bbox, crs, properties,
+        features
 
-    abstract type AbstractPosition{T <: Real} <: AbstractVector{T} end
-    geotype(::AbstractPosition) = :Position
-    xcoord(::AbstractPosition) = error("xcoord(::AbstractPosition) not defined.")
-    ycoord(::AbstractPosition) = error("ycoord(::AbstractPosition) not defined.")
-    # optional
-    zcoord(::AbstractPosition) = error("zcoord(::AbstractPosition) not defined.")
-    hasz(::AbstractPosition) = false
-    coordinates(p::AbstractPosition) = hasz(p) ? Float64[xcoord(p),ycoord(p),zcoord(p)] : Float64[xcoord(p),ycoord(p)]
-    # (Array-like indexing # http://julia.readthedocs.org/en/latest/manual/arrays/#arrays)
-    Base.eltype(p::AbstractPosition{T}) where {T <: Real} = T
-    Base.ndims(AbstractPosition) = 1
-    Base.length(p::AbstractPosition) = hasz(p) ? 3 : 2
-    Base.size(p::AbstractPosition) = (length(p),)
-    Base.size(p::AbstractPosition, n::Int) = (n == 1) ? length(p) : 1
-    Base.getindex(p::AbstractPosition, i::Int) = (i==1) ? xcoord(p) : (i==2) ? ycoord(p) : (i==3) ? zcoord(p) : nothing
-    Base.convert(::Type{Vector{Float64}}, p::AbstractPosition) = coordinates(p)
-    # Base.linearindexing{T <: AbstractPosition}(::Type{T}) = LinearFast()
+include("operations.jl")
+include("geotypes.jl")
+include("plotrecipes.jl")
 
-    abstract type AbstractGeometry end
-    coordinates(obj::AbstractGeometry) = error("coordinates(::AbstractGeometry) not defined.")
-
-        abstract type AbstractPoint <: AbstractGeometry end
-        geotype(::AbstractPoint) = :Point
-
-        abstract type AbstractMultiPoint <: AbstractGeometry end
-        geotype(::AbstractMultiPoint) = :MultiPoint
-
-        abstract type AbstractLineString <: AbstractGeometry end
-        geotype(::AbstractLineString) = :LineString
-
-        abstract type AbstractMultiLineString <: AbstractGeometry end
-        geotype(::AbstractMultiLineString) = :MultiLineString
-
-        abstract type AbstractPolygon <: AbstractGeometry end
-        geotype(::AbstractPolygon) = :Polygon
-
-        abstract type AbstractMultiPolygon <: AbstractGeometry end
-        geotype(::AbstractMultiPolygon) = :MultiPolygon
-
-        abstract type AbstractGeometryCollection <: AbstractGeometry end
-        geotype(::AbstractGeometryCollection) = :GeometryCollection
-        geometries(obj::AbstractGeometryCollection) = error("geometries(::AbstractGeometryCollection) not defined.")
-
-    abstract type AbstractFeature end
-    geotype(::AbstractFeature) = :Feature
-    geometry(obj::AbstractFeature) = error("geometry(::AbstractFeature) not defined.")
-    # optional
-    properties(obj::AbstractFeature) = Dict{String,Any}()
-    bbox(obj::AbstractFeature) = nothing
-    crs(obj::AbstractFeature) = nothing
-
-    abstract type AbstractFeatureCollection end
-    geotype(::AbstractFeatureCollection) = :FeatureCollection
-    features(obj::AbstractFeatureCollection) = error("features(::AbstractFeatureCollection) not defined.")
-    # optional
-    bbox(obj::AbstractFeatureCollection) = nothing
-    crs(obj::AbstractFeatureCollection) = nothing
-
-    include("operations.jl")
-    include("geotypes.jl")
-    include("plotrecipes.jl")
 end

--- a/src/GeoInterface.jl
+++ b/src/GeoInterface.jl
@@ -15,15 +15,16 @@ export  AbstractPosition, Position,
         AbstractFeature, Feature,
         AbstractFeatureCollection, FeatureCollection,
 
-        geotype, # methods
+        geotype,
         xcoord, ycoord, zcoord, hasz,
         coordinates,
         geometries,
         geometry, bbox, crs, properties,
         features
 
-include("operations.jl")
 include("geotypes.jl")
+include("features.jl")
+include("operations.jl")
 include("plotrecipes.jl")
 
 end

--- a/src/features.jl
+++ b/src/features.jl
@@ -1,0 +1,71 @@
+# Coordinate Reference System Objects
+# (has keys "type" and "properties")
+# TODO: Handle full CRS spec
+const CRS = Dict{String,Any}
+
+# Bounding Boxes
+# The value of the bbox member must be a 2*n array,
+# where n is the number of dimensions represented in the contained geometries,
+# with the lowest values for all axes followed by the highest values.
+
+# The axes order of a bbox follows the axes order of geometries.
+# In addition, the coordinate reference system for the bbox is assumed to match
+# the coordinate reference system of the GeoJSON object of which it is a member.
+const BBox = AbstractVector{<:Number}
+
+
+mutable struct GeometryCollection{T} <: AbstractGeometryCollection
+    geometries::T
+end
+
+# Why plural? why not just geometry for everything?
+geometries(collection::GeometryCollection) = collection.geometries
+geometries(obj::T) where T<:AbstractGeometryCollection = error("geometries(::$T) not defined.")
+
+
+abstract type AbstractFeature end
+geotype(::AbstractFeature) = :Feature
+
+crs(obj::AbstractFeature) = nothing
+# optional
+properties(obj::AbstractFeature) = Dict{String,Any}()
+bbox(obj::AbstractFeature) = nothing
+# geometry(obj::T) where {T<:AbstractFeature} = error("geometry(::$T) not defined.")
+
+
+mutable struct Feature{G<:Union{Nothing,AbstractGeometry},
+                       P<:Union{Nothing,Dict{String,Any}}} <: AbstractFeature
+    geometry::G
+    properties::P
+end
+Feature(geometry::Union{Nothing,AbstractGeometry}) = Feature(geometry, Dict{String,Any}())
+Feature(properties::Dict{String,Any}) = Feature(nothing, properties)
+
+properties(feature::Feature) = feature.properties
+bbox(feature::Feature) = get(feature.properties, "bbox", nothing)
+crs(feature::Feature) = get(feature.properties, "crs", nothing)
+geometry(feature::Feature) = feature.geometry
+
+
+
+abstract type AbstractFeatureCollection end
+geotype(::AbstractFeatureCollection) = :FeatureCollection
+
+features(obj::T) where {T<:AbstractFeatureCollection} = error("features(::$T) not defined.")
+bbox(obj::AbstractFeatureCollection) = nothing # optional
+crs(obj::AbstractFeatureCollection) = nothing # optional
+
+
+mutable struct FeatureCollection{T <: AbstractVector{<:AbstractFeature},
+                                 B <: Union{Nothing,BBox},
+                                 C <: Union{Nothing,CRS}} <: AbstractFeatureCollection
+    features::T
+    bbox::B
+    crs::C
+end
+# FeatureCollection(fc::AbstractFeatureCollection) = FeatureCollection(fc, nothing, nothing)
+
+features(fc::FeatureCollection) = fc.features
+bbox(fc::FeatureCollection) = fc.bbox
+crs(fc::FeatureCollection) = fc.crs
+

--- a/src/geotypes.jl
+++ b/src/geotypes.jl
@@ -11,135 +11,170 @@ const CRS = Dict{String,Any}
 # The axes order of a bbox follows the axes order of geometries.
 # In addition, the coordinate reference system for the bbox is assumed to match
 # the coordinate reference system of the GeoJSON object of which it is a member.
-const BBox = Vector{Float64}
+const BBox = AbstractVector{Number}
 
-const Position = Vector{Float64}
-# (x, y, [z, ...]) - meaning of additional elements undefined.
-# In an object's contained geometries, Positions must have uniform dimensions.
-geotype(::Position) = :Position
-xcoord(p::Position) = p[1]
-ycoord(p::Position) = p[2]
-zcoord(p::Position) = hasz(p) ? p[3] : zero(T)
-hasz(p::Position) = length(p) >= 3
-coordinates(obj::Position) = obj
+const Position = AbstractVector{Number}
 
-coordinates(obj::Vector{Position}) = obj
-coordinates(obj::Vector{T}) where {T <: AbstractPosition} =                    Position[map(coordinates, obj)...]
-coordinates(obj::Vector{T}) where {T <: AbstractPoint} =                       Position[map(coordinates, obj)...]
 
-coordinates(obj::Vector{Vector{Position}}) = obj
-coordinates(obj::Vector{Vector{T}}) where {T <: AbstractPosition} =            Vector{Position}[map(coordinates, obj)...]
-coordinates(obj::Vector{Vector{T}}) where {T <: AbstractPoint} =               Vector{Position}[map(coordinates, obj)...]
-coordinates(obj::Vector{T}) where {T <: AbstractLineString} =                  Vector{Position}[map(coordinates, obj)...]
+abstract type AbstractPosition{T <: Number} <: AbstractVector{T} end
+geotype(::AbstractPosition) = :Position
+# Array-like indexing # http://julia.readthedocs.org/en/latest/manual/arrays/#arrays)
+Base.eltype(p::AbstractPosition{T}) where {T <: Real} = T
+Base.ndims(AbstractPosition) = 1
+Base.length(p::AbstractPosition) = hasz(p) ? 3 : 2
+Base.size(p::AbstractPosition) = (length(p),)
+Base.size(p::AbstractPosition, n::Int) = (n == 1) ? length(p) : 1
+Base.getindex(p::AbstractPosition, i::Int) = (i==1) ? xcoord(p) : (i==2) ? ycoord(p) : (i==3) ? zcoord(p) : nothing
 
-coordinates(obj::Vector{Vector{Vector{Position}}}) = obj
-coordinates(obj::Vector{Vector{Vector{T}}}) where {T <: AbstractPosition} =    Vector{Vector{Position}}[map(coordinates, obj)...]
-coordinates(obj::Vector{Vector{Vector{T}}}) where {T <: AbstractPoint} =       Vector{Vector{Position}}[map(coordinates, obj)...]
-coordinates(obj::Vector{Vector{T}}) where {T <: AbstractLineString} =          Vector{Vector{Position}}[map(coordinates, obj)...]
-coordinates(obj::Vector{T}) where {T <: AbstractPolygon} =                     Vector{Vector{Position}}[map(coordinates, obj)...]
+
+abstract type AbstractGeometry end
+
+abstract type AbstractPoint <: AbstractGeometry end
+geotype(::AbstractPoint) = :Point
+
+abstract type AbstractMultiPoint <: AbstractGeometry end
+geotype(::AbstractMultiPoint) = :MultiPoint
+
+abstract type AbstractLineString <: AbstractGeometry end
+geotype(::AbstractLineString) = :LineString
+
+abstract type AbstractMultiLineString <: AbstractGeometry end
+geotype(::AbstractMultiLineString) = :MultiLineString
+
+abstract type AbstractPolygon <: AbstractGeometry end
+geotype(::AbstractPolygon) = :Polygon
+
+abstract type AbstractMultiPolygon <: AbstractGeometry end
+geotype(::AbstractMultiPolygon) = :MultiPolygon
+
+abstract type AbstractGeometryCollection <: AbstractGeometry end
+geotype(::AbstractGeometryCollection) = :GeometryCollection
+
+abstract type AbstractFeature end
+geotype(::AbstractFeature) = :Feature
+
+abstract type AbstractFeatureCollection end
+geotype(::AbstractFeatureCollection) = :FeatureCollection
+
 
 mutable struct Point <: AbstractPoint
     coordinates::Position
 end
-Point(x::Float64,y::Float64) = Point([x,y])
-Point(x::Float64,y::Float64,z::Float64) = Point([x,y,z])
+Point(x, y) = Point([x, y])
+Point(x, y, z) = Point([x, y, z])
 Point(point::AbstractPosition) = Point(coordinates(point))
 Point(point::AbstractPoint) = Point(coordinates(point))
 
-mutable struct MultiPoint <: AbstractMultiPoint
-    coordinates::Vector{Position}
-end
-MultiPoint(point::Position) = MultiPoint(Position[point])
-MultiPoint(point::AbstractPosition) = MultiPoint(Position[coordinates(point)])
-MultiPoint(point::AbstractPoint) = MultiPoint(Position[coordinates(point)])
 
-MultiPoint(points::Vector{T}) where {T <: AbstractPosition} = MultiPoint(coordinates(points))
-MultiPoint(points::Vector{T}) where {T <: AbstractPoint} = MultiPoint(coordinates(points))
+mutable struct MultiPoint{T<:AbstractVector{<:AbstractPosition}} <: AbstractMultiPoint
+    coordinates::T
+end
+MultiPoint(point::AbstractPosition) = MultiPoint([point])
+MultiPoint(point::AbstractPosition) = MultiPoint([coordinates(point)])
+MultiPoint(point::AbstractPoint) = MultiPoint([coordinates(point)])
+
+MultiPoint(points::AbstractVector{<:AbstractPosition}) = MultiPoint(coordinates(points))
+MultiPoint(points::AbstractVector{<:AbstractPoint}) = MultiPoint(coordinates(points))
 MultiPoint(points::AbstractMultiPoint) = MultiPoint(coordinates(points))
 MultiPoint(line::AbstractLineString) = MultiPoint(coordinates(line))
 
-mutable struct LineString <: AbstractLineString
-    coordinates::Vector{Position}
+
+mutable struct LineString{T<:AbstractVector{<:AbstractPosition}} <: AbstractLineString
+    coordinates::T
 end
-LineString(points::Vector{T}) where {T <: AbstractPosition} = LineString(coordinates(points))
-LineString(points::Vector{T}) where {T <: AbstractPoint} = LineString(coordinates(points))
+LineString(points::AbstractVector{<:AbstractPosition}) = LineString(coordinates(points))
+LineString(points::AbstractVector{<:AbstractPoint}) = LineString(coordinates(points))
 LineString(points::AbstractMultiPoint) = LineString(coordinates(points))
 LineString(line::AbstractLineString) = LineString(coordinates(line))
 
-mutable struct MultiLineString <: AbstractMultiLineString
-    coordinates::Vector{Vector{Position}}
-end
-MultiLineString(line::Vector{Position}) = MultiLineString(Vector{Position}[line])
-MultiLineString(line::Vector{T}) where {T <: AbstractPosition} = MultiLineString(Vector{Position}[coordinates(line)])
-MultiLineString(line::Vector{T}) where {T <: AbstractPoint} = MultiLineString(Vector{Position}[coordinates(line)])
-MultiLineString(line::AbstractLineString) = MultiLineString(Vector{Position}[coordinates(line)])
 
-MultiLineString(lines::Vector{Vector{T}}) where {T <: AbstractPosition} = MultiLineString(coordinates(lines))
-MultiLineString(lines::Vector{Vector{T}}) where {T <: AbstractPoint} = MultiLineString(coordinates(lines))
-MultiLineString(lines::Vector{T}) where {T <: AbstractLineString} = MultiLineString(Vector{Position}[map(coordinates,lines)])
+mutable struct MultiLineString{T<:AbstractVector{<:AbstractVector{<:AbstractPosition}}} <: AbstractMultiLineString
+    coordinates::T
+end
+MultiLineString(line::AbstractVector{<:AbstractPosition}) =
+    MultiLineString(Vector{Position}[line])
+MultiLineString(line::AbstractVector{<:AbstractPosition}) =
+    MultiLineString([coordinates(line)])
+MultiLineString(line::AbstractVector{AbstractPoint}) =
+    MultiLineString([coordinates(line)])
+MultiLineString(line::AbstractLineString) = MultiLineString([coordinates(line)])
+
+MultiLineString(lines::AbstractVector{<:AbstractVector{<:AbstractPosition}}) = MultiLineString(coordinates(lines))
+MultiLineString(lines::AbstractVector{<:AbstractVector{<:AbstractPoint}}) = MultiLineString(coordinates(lines))
+MultiLineString(lines::AbstractVector{<:AbstractLineString}) = MultiLineString([map(coordinates,lines)])
 MultiLineString(lines::AbstractMultiLineString) = MultiLineString(coordinates(lines))
 MultiLineString(poly::AbstractPolygon) = MultiLineString(coordinates(poly))
 
-mutable struct Polygon <: AbstractPolygon
-    coordinates::Vector{Vector{Position}}
-end
-Polygon(line::Vector{Position}) = Polygon(Vector{Position}[line])
-Polygon(line::Vector{T}) where {T <: AbstractPosition} = Polygon(Vector{Position}[coordinates(line)])
-Polygon(line::Vector{T}) where {T <: AbstractPoint} = Polygon(Vector{Position}[coordinates(line)])
-Polygon(line::AbstractLineString) = Polygon(Vector{Position}[coordinates(line)])
 
-Polygon(lines::Vector{Vector{T}}) where {T <: AbstractPosition} = Polygon(coordinates(lines))
-Polygon(lines::Vector{Vector{T}}) where {T <: AbstractPoint} = Polygon(coordinates(lines))
-Polygon(lines::Vector{T}) where {T <: AbstractLineString} = Polygon(coordinates(lines))
+mutable struct Polygon{T<:AbstractVector{<:AbstractVector{<:AbstractPosition}}} <: AbstractPolygon
+    coordinates::T
+end
+Polygon(line::AbstractVector{<:AbstractPosition}) = Polygon([line])
+Polygon(line::AbstractVector{<:AbstractPosition}) = Polygon([coordinates(line)])
+Polygon(line::AbstractVector{<:AbstractPoint}) = Polygon([coordinates(line)])
+Polygon(line::AbstractLineString) = Polygon([coordinates(line)])
+
+Polygon(lines::AbstractVector{<:AbstractVector{<:AbstractPosition}}) = Polygon(coordinates(lines))
+Polygon(lines::AbstractVector{<:AbstractVector{<:AbstractPoint}}) = Polygon(coordinates(lines))
+Polygon(lines::AbstractVector{<:AbstractLineString}) = Polygon(coordinates(lines))
 Polygon(lines::AbstractMultiLineString) = Polygon(coordinates(lines))
 Polygon(poly::AbstractPolygon) = Polygon(coordinates(poly))
 
-mutable struct MultiPolygon <: AbstractMultiPolygon
-    coordinates::Vector{Vector{Vector{Position}}}
+
+mutable struct MultiPolygon{T<:Vector{Vector{Vector{Position}}}} <: AbstractMultiPolygon
+    coordinates::T
 end
-MultiPolygon(line::Vector{Position}) = MultiPolygon(Vector{Vector{Position}}[Vector{Position}[line]])
-MultiPolygon(line::Vector{T}) where {T <: AbstractPosition} = MultiPolygon(Vector{Vector{Position}}[Vector{Position}[coordinates(line)]])
-MultiPolygon(line::Vector{T}) where {T <: AbstractPoint} = MultiPolygon(Vector{Vector{Position}}[Vector{Position}[coordinates(line)]])
-MultiPolygon(line::AbstractLineString) = MultiPolygon(Vector{Vector{Position}}[Vector{Position}[coordinates(line)]])
+# FIXME MultiPolygon(line::AbstractVector{T}) where T <: AbstractPosition = MultiPolygon(Vector{Vector{Position}}[Vector{Position}[line]])
+MultiPolygon(line::AbstractVector{<:AbstractPosition}) =
+    MultiPolygon([Vector{Position}[coordinates(line)]])
+MultiPolygon(line::AbstractVector{<:AbstractPoint}) =
+    MultiPolygon([Vector{Position}[coordinates(line)]])
+MultiPolygon(line::AbstractLineString) = MultiPolygon([[coordinates(line)]])
 
-MultiPolygon(poly::Vector{Vector{T}}) where {T <: AbstractPosition} = MultiPolygon(Vector{Vector{Position}}[coordinates(poly)])
-MultiPolygon(poly::Vector{Vector{T}}) where {T <: AbstractPoint} = MultiPolygon(Vector{Vector{Position}}[coordinates(poly)])
-MultiPolygon(poly::Vector{T}) where {T <: AbstractLineString} = MultiPolygon(Vector{Vector{Position}}[coordinates(poly)])
-MultiPolygon(poly::AbstractMultiLineString) = MultiPolygon(Vector{Vector{Position}}[coordinates(poly)])
-MultiPolygon(poly::AbstractPolygon) = MultiPolygon(Vector{Vector{Position}}[coordinates(poly)])
+MultiPolygon(poly::AbstractVector{<:AbstractVector{<:AbstractPosition}}) =
+    MultiPolygon([coordinates(poly)])
+MultiPolygon(poly::AbstractVector{<:AbstractVector{<:AbstractPoint}}) =
+    MultiPolygon([coordinates(poly)])
+MultiPolygon(poly::AbstractVector{<:AbstractLineString}) =
+    MultiPolygon([coordinates(poly)])
+MultiPolygon(poly::AbstractMultiLineString) = MultiPolygon([coordinates(poly)])
+MultiPolygon(poly::AbstractPolygon) = MultiPolygon([coordinates(poly)])
 
-MultiPolygon(polys::Vector{Vector{Vector{T}}}) where {T <: AbstractPosition} = MultiPolygon(coordinates(polys))
-MultiPolygon(polys::Vector{Vector{Vector{T}}}) where {T <: AbstractPoint} = MultiPolygon(coordinates(polys))
-MultiPolygon(polys::Vector{Vector{T}}) where {T <: AbstractLineString} = MultiPolygon(coordinates(polys))
-MultiPolygon(polys::Vector{T}) where {T <: AbstractPolygon} = MultiPolygon(coordinates(polys))
+MultiPolygon(polys::AbstractVector{<:AbstractVector{<:AbstractVector{<:AbstractPosition}}}) =
+    MultiPolygon(coordinates(polys))
+MultiPolygon(polys::AbstractVector{<:AbstractVector{<:AbstractVector{<:AbstractPoint}}}) =
+    MultiPolygon(coordinates(polys))
+MultiPolygon(polys::<:AbstractVector{<:AbstractVector{<:AbstractLineStringT}}) =
+    MultiPolygon(coordinates(polys))
+MultiPolygon(polys::AbstractVector{<:AbstractPolygonT}) = MultiPolygon(coordinates(polys))
 MultiPolygon(polys::AbstractMultiPolygon) = MultiPolygon(coordinates(polys))
+
 
 for geom in (:MultiPolygon, :Polygon, :MultiLineString, :LineString, :MultiPoint, :Point)
     @eval coordinates(obj::$geom) = obj.coordinates
 end
 
-mutable struct GeometryCollection <: AbstractGeometryCollection
-    geometries::Vector
+mutable struct GeometryCollection{V} <: AbstractGeometryCollection
+    geometries::V
 end
-geometries(collection::GeometryCollection) = collection.geometries
 
-mutable struct Feature <: AbstractFeature
-    geometry::Union{Nothing, AbstractGeometry}
-    properties::Union{Nothing, Dict{String,Any}}
+mutable struct Feature{G<Union{Nothing,AbstractGeometry},
+                       P<:Union{Nothing,Dict{String,Any}}} <: AbstractFeature
+    geometry::G
+    properties::P
 end
-Feature(geometry::Union{Nothing,GeoInterface.AbstractGeometry}) = Feature(geometry, Dict{String,Any}())
+Feature(geometry::Union{Nothing,GeoInterface.AbstractGeometry}) =
+    Feature(geometry, Dict{String,Any}())
 Feature(properties::Dict{String,Any}) = Feature(nothing, properties)
-geometry(feature::Feature) = feature.geometry
-properties(feature::Feature) = feature.properties
-bbox(feature::Feature) = get(feature.properties, "bbox", nothing)
-crs(feature::Feature) = get(feature.properties, "crs", nothing)
 
-mutable struct FeatureCollection{T <: AbstractFeature} <: AbstractFeatureCollection
-    features::Vector{T}
-    bbox::Union{Nothing, BBox}
-    crs::Union{Nothing, CRS}
+
+mutable struct FeatureCollection{T <: AbstractVector{<: AbstractFeature},
+                                 B <: Union{Nothing, BBox},
+                                 C <: Union{Nothing,CRS}} <: AbstractFeatureCollection
+    features::T
+    bbox::B
+    crs::C
 end
-FeatureCollection(fc::Vector{T}) where {T <: AbstractFeature} = FeatureCollection(fc, nothing, nothing)
-features(fc::FeatureCollection) = fc.features
-bbox(fc::FeatureCollection) = fc.bbox
-crs(fc::FeatureCollection) = fc.crs
+FeatureCollection(fc::AbstractFeatureCollection{<:AbstractFeature}) =
+    FeatureCollection(fc, nothing, nothing)
+

--- a/src/geotypes.jl
+++ b/src/geotypes.jl
@@ -1,42 +1,53 @@
-# Coordinate Reference System Objects
-# (has keys "type" and "properties")
-# TODO: Handle full CRS spec
-const CRS = Dict{String,Any}
 
-# Bounding Boxes
-# The value of the bbox member must be a 2*n array,
-# where n is the number of dimensions represented in the contained geometries,
-# with the lowest values for all axes followed by the highest values.
-
-# The axes order of a bbox follows the axes order of geometries.
-# In addition, the coordinate reference system for the bbox is assumed to match
-# the coordinate reference system of the GeoJSON object of which it is a member.
-const BBox = AbstractVector{Number}
-
-const Position = AbstractVector{Number}
-
-
-abstract type AbstractPosition{T <: Number} <: AbstractVector{T} end
+abstract type AbstractPosition{T<:Number} <: AbstractVector{T} end
 geotype(::AbstractPosition) = :Position
-# Array-like indexing # http://julia.readthedocs.org/en/latest/manual/arrays/#arrays)
-Base.eltype(p::AbstractPosition{T}) where {T <: Real} = T
+
+xcoord(::T) where T <: AbstractPosition = error("xcoord(::$T) not defined.")
+ycoord(::T) where T <: AbstractPosition = error("ycoord(::$T) not defined.")
+zcoord(::T) where T <: AbstractPosition = error("zcoord(::$T) not defined.") # optional
+
+hasz(::AbstractPosition) = false
+
+# (x, y, [z, ...]) - meaning of additional elements undefined.
+# In an object's contained geometries, Positions must have uniform dimensions.
+
+
+# Array interface
+Base.eltype(p::AbstractPosition{T}) where T = T
 Base.ndims(AbstractPosition) = 1
 Base.length(p::AbstractPosition) = hasz(p) ? 3 : 2
 Base.size(p::AbstractPosition) = (length(p),)
 Base.size(p::AbstractPosition, n::Int) = (n == 1) ? length(p) : 1
 Base.getindex(p::AbstractPosition, i::Int) = (i==1) ? xcoord(p) : (i==2) ? ycoord(p) : (i==3) ? zcoord(p) : nothing
+# Base.linearindexing{T <: AbstractPosition}(::Type{T}) = LinearFast()
+
+
+const Position = Vector{Float64} # Position isn't actually <: AbstractPosition
+geotype(::Position) = :Position
+
+xcoord(p::Position) = p[1]
+ycoord(p::Position) = p[2]
+zcoord(p::Position) = hasz(p) ? p[3] : zero(T)
+
+hasz(p::Position) = length(p) >= 3
+
+Base.convert(T::Type{Position}, p::AbstractPosition) = coordinates(p)
+
+const AnyPosition = Vector{Any} # Position isn't actually <: AbstractPosition
+const NumPosition = Vector{<:Number} # Position isn't actually <: AbstractPosition
 
 
 abstract type AbstractGeometry end
 
+
 abstract type AbstractPoint <: AbstractGeometry end
 geotype(::AbstractPoint) = :Point
 
-abstract type AbstractMultiPoint <: AbstractGeometry end
-geotype(::AbstractMultiPoint) = :MultiPoint
-
 abstract type AbstractLineString <: AbstractGeometry end
 geotype(::AbstractLineString) = :LineString
+
+abstract type AbstractMultiPoint <: AbstractGeometry end
+geotype(::AbstractMultiPoint) = :MultiPoint
 
 abstract type AbstractMultiLineString <: AbstractGeometry end
 geotype(::AbstractMultiLineString) = :MultiLineString
@@ -50,131 +61,92 @@ geotype(::AbstractMultiPolygon) = :MultiPolygon
 abstract type AbstractGeometryCollection <: AbstractGeometry end
 geotype(::AbstractGeometryCollection) = :GeometryCollection
 
-abstract type AbstractFeature end
-geotype(::AbstractFeature) = :Feature
 
-abstract type AbstractFeatureCollection end
-geotype(::AbstractFeatureCollection) = :FeatureCollection
+# Define the common union types to keep methods DRY
+# Position types are separated to avoid method ambiguities.
+
+const Pos = Union{Position,AbstractPosition}
+const ConvertPos = Union{AnyPosition}
+const SinglePosVec = AbstractVector{<:Union{Pos}}
+const DoublePosVec = AbstractVector{<:AbstractVector{<:Union{Pos,AnyPosition,NumPosition}}}
+
+const SingleVec = Union{AbstractVector{<:ConvertPos},
+                        AbstractVector{<:AbstractPoint}, AbstractLineString}
+
+const DoubleVec = Union{AbstractVector{<:AbstractVector{<:ConvertPos}},
+                        AbstractVector{<:AbstractVector{<:AbstractPoint}},
+                        AbstractVector{<:AbstractLineString},
+                        AbstractMultiLineString,
+                        AbstractPolygon}
+
+const TripleVec = Union{AbstractVector{<:AbstractVector{<:AbstractVector{<:AbstractPoint}}},
+                        AbstractVector{<:AbstractVector{<:AbstractLineString}},
+                        AbstractVector{<:AbstractMultiLineString},
+                        AbstractVector{<:AbstractPolygon},
+                        AbstractMultiPolygon}
 
 
-mutable struct Point <: AbstractPoint
-    coordinates::Position
+mutable struct Point{T<:Pos} <: AbstractPoint
+    coordinates::T
 end
-Point(x, y) = Point([x, y])
-Point(x, y, z) = Point([x, y, z])
-Point(point::AbstractPosition) = Point(coordinates(point))
+Point(x, y) = Point([promote_type([x, y])...])
+Point(x, y, z) = Point(promote_type([x, y, z]))
+Point(pos::AbstractPosition) = Point(coordinates(pos))
+Point(pos::Union{AnyPosition,NumPosition}) = Point(coordinates(pos))
 Point(point::AbstractPoint) = Point(coordinates(point))
 
 
-mutable struct MultiPoint{T<:AbstractVector{<:AbstractPosition}} <: AbstractMultiPoint
+mutable struct LineString{T<:AbstractVector{<:Pos}} <: AbstractLineString
     coordinates::T
 end
-MultiPoint(point::AbstractPosition) = MultiPoint([point])
-MultiPoint(point::AbstractPosition) = MultiPoint([coordinates(point)])
-MultiPoint(point::AbstractPoint) = MultiPoint([coordinates(point)])
-
-MultiPoint(points::AbstractVector{<:AbstractPosition}) = MultiPoint(coordinates(points))
-MultiPoint(points::AbstractVector{<:AbstractPoint}) = MultiPoint(coordinates(points))
-MultiPoint(points::AbstractMultiPoint) = MultiPoint(coordinates(points))
-MultiPoint(line::AbstractLineString) = MultiPoint(coordinates(line))
+LineString(x::Union{SingleVec,SinglePosVec}) = LineString(coordinates(x))
 
 
-mutable struct LineString{T<:AbstractVector{<:AbstractPosition}} <: AbstractLineString
+mutable struct MultiPoint{T<:AbstractVector{<:Pos}} <: AbstractMultiPoint
     coordinates::T
 end
-LineString(points::AbstractVector{<:AbstractPosition}) = LineString(coordinates(points))
-LineString(points::AbstractVector{<:AbstractPoint}) = LineString(coordinates(points))
-LineString(points::AbstractMultiPoint) = LineString(coordinates(points))
-LineString(line::AbstractLineString) = LineString(coordinates(line))
+MultiPoint(x::SingleVec) = MultiPoint([coordinates(x)])
+MultiPoint(x::Union{DoubleVec,DoublePosVec}) = MultiPoint(coordinates(x))
 
 
-mutable struct MultiLineString{T<:AbstractVector{<:AbstractVector{<:AbstractPosition}}} <: AbstractMultiLineString
+mutable struct MultiLineString{T<:AbstractVector{<:AbstractVector{<:Pos}}} <: AbstractMultiLineString
     coordinates::T
 end
-MultiLineString(line::AbstractVector{<:AbstractPosition}) =
-    MultiLineString(Vector{Position}[line])
-MultiLineString(line::AbstractVector{<:AbstractPosition}) =
-    MultiLineString([coordinates(line)])
-MultiLineString(line::AbstractVector{AbstractPoint}) =
-    MultiLineString([coordinates(line)])
-MultiLineString(line::AbstractLineString) = MultiLineString([coordinates(line)])
+MultiLineString(x::Union{SingleVec,SinglePosVec}) = MultiLineString([coordinates(x)])
+MultiLineString(x::DoubleVec) = MultiLineString(coordinates(x))
 
-MultiLineString(lines::AbstractVector{<:AbstractVector{<:AbstractPosition}}) = MultiLineString(coordinates(lines))
-MultiLineString(lines::AbstractVector{<:AbstractVector{<:AbstractPoint}}) = MultiLineString(coordinates(lines))
-MultiLineString(lines::AbstractVector{<:AbstractLineString}) = MultiLineString([map(coordinates,lines)])
-MultiLineString(lines::AbstractMultiLineString) = MultiLineString(coordinates(lines))
-MultiLineString(poly::AbstractPolygon) = MultiLineString(coordinates(poly))
-
-
-mutable struct Polygon{T<:AbstractVector{<:AbstractVector{<:AbstractPosition}}} <: AbstractPolygon
+mutable struct Polygon{T<:AbstractVector{<:AbstractVector{<:Pos}}} <: AbstractPolygon
     coordinates::T
 end
-Polygon(line::AbstractVector{<:AbstractPosition}) = Polygon([line])
-Polygon(line::AbstractVector{<:AbstractPosition}) = Polygon([coordinates(line)])
-Polygon(line::AbstractVector{<:AbstractPoint}) = Polygon([coordinates(line)])
-Polygon(line::AbstractLineString) = Polygon([coordinates(line)])
-
-Polygon(lines::AbstractVector{<:AbstractVector{<:AbstractPosition}}) = Polygon(coordinates(lines))
-Polygon(lines::AbstractVector{<:AbstractVector{<:AbstractPoint}}) = Polygon(coordinates(lines))
-Polygon(lines::AbstractVector{<:AbstractLineString}) = Polygon(coordinates(lines))
-Polygon(lines::AbstractMultiLineString) = Polygon(coordinates(lines))
-Polygon(poly::AbstractPolygon) = Polygon(coordinates(poly))
+Polygon(x::Union{SingleVec,SinglePosVec}) = Polygon([coordinates(x)])
+Polygon(x::DoubleVec) = Polygon(coordinates(x))
 
 
-mutable struct MultiPolygon{T<:Vector{Vector{Vector{Position}}}} <: AbstractMultiPolygon
+mutable struct MultiPolygon{T<:AbstractVector{<:AbstractVector{<:AbstractVector{<:Pos}}}} <: AbstractMultiPolygon
     coordinates::T
 end
-# FIXME MultiPolygon(line::AbstractVector{T}) where T <: AbstractPosition = MultiPolygon(Vector{Vector{Position}}[Vector{Position}[line]])
-MultiPolygon(line::AbstractVector{<:AbstractPosition}) =
-    MultiPolygon([Vector{Position}[coordinates(line)]])
-MultiPolygon(line::AbstractVector{<:AbstractPoint}) =
-    MultiPolygon([Vector{Position}[coordinates(line)]])
-MultiPolygon(line::AbstractLineString) = MultiPolygon([[coordinates(line)]])
+MultiPolygon(x::Union{SingleVec, SinglePosVec}) = MultiPolygon([[coordinates(x)]])
+MultiPolygon(x::Union{DoubleVec, DoublePosVec}) = MultiPolygon([coordinates(x)])
+MultiPolygon(x::TripleVec) = coordinates(x)
 
-MultiPolygon(poly::AbstractVector{<:AbstractVector{<:AbstractPosition}}) =
-    MultiPolygon([coordinates(poly)])
-MultiPolygon(poly::AbstractVector{<:AbstractVector{<:AbstractPoint}}) =
-    MultiPolygon([coordinates(poly)])
-MultiPolygon(poly::AbstractVector{<:AbstractLineString}) =
-    MultiPolygon([coordinates(poly)])
-MultiPolygon(poly::AbstractMultiLineString) = MultiPolygon([coordinates(poly)])
-MultiPolygon(poly::AbstractPolygon) = MultiPolygon([coordinates(poly)])
 
-MultiPolygon(polys::AbstractVector{<:AbstractVector{<:AbstractVector{<:AbstractPosition}}}) =
-    MultiPolygon(coordinates(polys))
-MultiPolygon(polys::AbstractVector{<:AbstractVector{<:AbstractVector{<:AbstractPoint}}}) =
-    MultiPolygon(coordinates(polys))
-MultiPolygon(polys::<:AbstractVector{<:AbstractVector{<:AbstractLineStringT}}) =
-    MultiPolygon(coordinates(polys))
-MultiPolygon(polys::AbstractVector{<:AbstractPolygonT}) = MultiPolygon(coordinates(polys))
-MultiPolygon(polys::AbstractMultiPolygon) = MultiPolygon(coordinates(polys))
+"""
+Get the coordinates of an object, or nested vectors of coordinates for nested objects
+"""
+function coordinates end
 
+coordinates(obj::Position) = obj
+# Shouldn't this also return the AbstractPosition unmodified?
+coordinates(p::AbstractPosition) = hasz(p) ? [xcoord(p), ycoord(p), zcoord(p)] : [xcoord(p), ycoord(p)]
+coordinates(obj::AbstractVector{<:Any}) = begin
+    coords = [obj...]
+    eltype(coords) <: Number || error("Coordinates $obj are not in Number")
+    coords
+end
+coordinates(obj::AbstractVector{<:Number}) = [promote_type(obj)...]
+coordinates(obj::AbstractVector) = coordinates.(obj)
+coordinates(obj::T) where T <: AbstractGeometry = error("coordinates(::$T) not defined.")
 
 for geom in (:MultiPolygon, :Polygon, :MultiLineString, :LineString, :MultiPoint, :Point)
     @eval coordinates(obj::$geom) = obj.coordinates
 end
-
-mutable struct GeometryCollection{V} <: AbstractGeometryCollection
-    geometries::V
-end
-
-mutable struct Feature{G<Union{Nothing,AbstractGeometry},
-                       P<:Union{Nothing,Dict{String,Any}}} <: AbstractFeature
-    geometry::G
-    properties::P
-end
-Feature(geometry::Union{Nothing,GeoInterface.AbstractGeometry}) =
-    Feature(geometry, Dict{String,Any}())
-Feature(properties::Dict{String,Any}) = Feature(nothing, properties)
-
-
-mutable struct FeatureCollection{T <: AbstractVector{<: AbstractFeature},
-                                 B <: Union{Nothing, BBox},
-                                 C <: Union{Nothing,CRS}} <: AbstractFeatureCollection
-    features::T
-    bbox::B
-    crs::C
-end
-FeatureCollection(fc::AbstractFeatureCollection{<:AbstractFeature}) =
-    FeatureCollection(fc, nothing, nothing)
-

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,0 +1,76 @@
+
+# Array-like indexing # http://julia.readthedocs.org/en/latest/manual/arrays/#arrays)
+Base.eltype(p::AbstractPosition{T}) where {T <: Real} = T
+Base.ndims(AbstractPosition) = 1
+Base.length(p::AbstractPosition) = hasz(p) ? 3 : 2
+Base.size(p::AbstractPosition) = (length(p),)
+Base.size(p::AbstractPosition, n::Int) = (n == 1) ? length(p) : 1
+Base.getindex(p::AbstractPosition, i::Int) = (i==1) ? xcoord(p) : (i==2) ? ycoord(p) : (i==3) ? zcoord(p) : nothing
+
+# Generalise this...
+Base.convert(T::Type{<:Vector{<:Float64}}, p::AbstractPosition) = coordinates(p)
+# Base.linearindexing{T <: AbstractPosition}(::Type{T}) = LinearFast()
+
+xcoord(::AbstractPosition) = error("xcoord(::AbstractPosition) not defined.")
+ycoord(::AbstractPosition) = error("ycoord(::AbstractPosition) not defined.")
+
+# optional
+zcoord(::AbstractPosition) = error("zcoord(::AbstractPosition) not defined.")
+hasz(::AbstractPosition) = false
+
+# (x, y, [z, ...]) - meaning of additional elements undefined.
+# In an object's contained geometries, Positions must have uniform dimensions.
+xcoord(p::Position) = p[1]
+ycoord(p::Position) = p[2]
+zcoord(p::Position) = hasz(p) ? p[3] : zero(T)
+
+hasz(p::Position) = length(p) >= 3
+
+coordinates(obj::Position) = obj
+
+
+# This should be done at compile time
+coordinates(p::AbstractPosition) = hasz(p) ? [xcoord(p), ycoord(p), zcoord(p)] : [xcoord(p), ycoord(p)]
+
+coordinates(obj::AbstractGeometry) = error("coordinates(::AbstractGeometry) not defined.")
+
+coordinates(obj::Vector{Position}) = obj
+coordinates(obj::Vector{T}) where {T <: AbstractPosition} =                    Position[map(coordinates, obj)...]
+coordinates(obj::Vector{T}) where {T <: AbstractPoint} =                       Position[map(coordinates, obj)...]
+
+coordinates(obj::Vector{Vector{Position}}) = obj
+coordinates(obj::Vector{Vector{T}}) where {T <: AbstractPosition} =            Vector{Position}[map(coordinates, obj)...]
+coordinates(obj::Vector{Vector{T}}) where {T <: AbstractPoint} =               Vector{Position}[map(coordinates, obj)...]
+coordinates(obj::Vector{T}) where {T <: AbstractLineString} =                  Vector{Position}[map(coordinates, obj)...]
+
+coordinates(obj::Vector{Vector{Vector{Position}}}) = obj
+coordinates(obj::Vector{Vector{Vector{T}}}) where {T <: AbstractPosition} =    Vector{Vector{Position}}[map(coordinates, obj)...]
+coordinates(obj::Vector{Vector{Vector{T}}}) where {T <: AbstractPoint} =       Vector{Vector{Position}}[map(coordinates, obj)...]
+coordinates(obj::Vector{Vector{T}}) where {T <: AbstractLineString} =          Vector{Vector{Position}}[map(coordinates, obj)...]
+coordinates(obj::Vector{T}) where {T <: AbstractPolygon} =                     Vector{Vector{Position}}[map(coordinates, obj)...]
+
+
+geometry(feature::Feature) = feature.geometry
+properties(feature::Feature) = feature.properties
+bbox(feature::Feature) = get(feature.properties, "bbox", nothing)
+crs(feature::Feature) = get(feature.properties, "crs", nothing)
+
+features(fc::FeatureCollection) = fc.features
+bbox(fc::FeatureCollection) = fc.bbox
+crs(fc::FeatureCollection) = fc.crs
+
+# optional
+properties(obj::AbstractFeature) = Dict{String,Any}()
+bbox(obj::AbstractFeature) = nothing
+
+features(obj::AbstractFeatureCollection) = error("features(::AbstractFeatureCollection) not defined.")
+# optional
+bbox(obj::AbstractFeatureCollection) = nothing
+
+crs(obj::AbstractFeature) = nothing
+crs(obj::AbstractFeatureCollection) = nothing
+
+# Why plural? why not just geometry for everything?
+geometries(obj::AbstractGeometryCollection) = error("geometries(::AbstractGeometryCollection) not defined.")
+geometries(collection::GeometryCollection) = collection.geometries
+geometry(obj::AbstractFeature) = error("geometry(::AbstractFeature) not defined.")

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,76 +1,39 @@
+"""
+What does this do
+"""
+function coordinates end
 
-# Array-like indexing # http://julia.readthedocs.org/en/latest/manual/arrays/#arrays)
-Base.eltype(p::AbstractPosition{T}) where {T <: Real} = T
-Base.ndims(AbstractPosition) = 1
-Base.length(p::AbstractPosition) = hasz(p) ? 3 : 2
-Base.size(p::AbstractPosition) = (length(p),)
-Base.size(p::AbstractPosition, n::Int) = (n == 1) ? length(p) : 1
-Base.getindex(p::AbstractPosition, i::Int) = (i==1) ? xcoord(p) : (i==2) ? ycoord(p) : (i==3) ? zcoord(p) : nothing
+"""
+What does this do
+"""
+function xcoord end
 
-# Generalise this...
-Base.convert(T::Type{<:Vector{<:Float64}}, p::AbstractPosition) = coordinates(p)
-# Base.linearindexing{T <: AbstractPosition}(::Type{T}) = LinearFast()
+"""
+What does this do
+"""
+function ycoord end
 
-xcoord(::AbstractPosition) = error("xcoord(::AbstractPosition) not defined.")
-ycoord(::AbstractPosition) = error("ycoord(::AbstractPosition) not defined.")
+"""
+What does this do
+"""
+function zcoord end
 
-# optional
-zcoord(::AbstractPosition) = error("zcoord(::AbstractPosition) not defined.")
-hasz(::AbstractPosition) = false
+"""
+What does this do
+"""
+function bbox end
 
-# (x, y, [z, ...]) - meaning of additional elements undefined.
-# In an object's contained geometries, Positions must have uniform dimensions.
-xcoord(p::Position) = p[1]
-ycoord(p::Position) = p[2]
-zcoord(p::Position) = hasz(p) ? p[3] : zero(T)
+"""
+What does this do
+"""
+function crs end
 
-hasz(p::Position) = length(p) >= 3
+"""
+What does this do
+"""
+function geometries end
 
-coordinates(obj::Position) = obj
-
-
-# This should be done at compile time
-coordinates(p::AbstractPosition) = hasz(p) ? [xcoord(p), ycoord(p), zcoord(p)] : [xcoord(p), ycoord(p)]
-
-coordinates(obj::AbstractGeometry) = error("coordinates(::AbstractGeometry) not defined.")
-
-coordinates(obj::Vector{Position}) = obj
-coordinates(obj::Vector{T}) where {T <: AbstractPosition} =                    Position[map(coordinates, obj)...]
-coordinates(obj::Vector{T}) where {T <: AbstractPoint} =                       Position[map(coordinates, obj)...]
-
-coordinates(obj::Vector{Vector{Position}}) = obj
-coordinates(obj::Vector{Vector{T}}) where {T <: AbstractPosition} =            Vector{Position}[map(coordinates, obj)...]
-coordinates(obj::Vector{Vector{T}}) where {T <: AbstractPoint} =               Vector{Position}[map(coordinates, obj)...]
-coordinates(obj::Vector{T}) where {T <: AbstractLineString} =                  Vector{Position}[map(coordinates, obj)...]
-
-coordinates(obj::Vector{Vector{Vector{Position}}}) = obj
-coordinates(obj::Vector{Vector{Vector{T}}}) where {T <: AbstractPosition} =    Vector{Vector{Position}}[map(coordinates, obj)...]
-coordinates(obj::Vector{Vector{Vector{T}}}) where {T <: AbstractPoint} =       Vector{Vector{Position}}[map(coordinates, obj)...]
-coordinates(obj::Vector{Vector{T}}) where {T <: AbstractLineString} =          Vector{Vector{Position}}[map(coordinates, obj)...]
-coordinates(obj::Vector{T}) where {T <: AbstractPolygon} =                     Vector{Vector{Position}}[map(coordinates, obj)...]
-
-
-geometry(feature::Feature) = feature.geometry
-properties(feature::Feature) = feature.properties
-bbox(feature::Feature) = get(feature.properties, "bbox", nothing)
-crs(feature::Feature) = get(feature.properties, "crs", nothing)
-
-features(fc::FeatureCollection) = fc.features
-bbox(fc::FeatureCollection) = fc.bbox
-crs(fc::FeatureCollection) = fc.crs
-
-# optional
-properties(obj::AbstractFeature) = Dict{String,Any}()
-bbox(obj::AbstractFeature) = nothing
-
-features(obj::AbstractFeatureCollection) = error("features(::AbstractFeatureCollection) not defined.")
-# optional
-bbox(obj::AbstractFeatureCollection) = nothing
-
-crs(obj::AbstractFeature) = nothing
-crs(obj::AbstractFeatureCollection) = nothing
-
-# Why plural? why not just geometry for everything?
-geometries(obj::AbstractGeometryCollection) = error("geometries(::AbstractGeometryCollection) not defined.")
-geometries(collection::GeometryCollection) = collection.geometries
-geometry(obj::AbstractFeature) = error("geometry(::AbstractFeature) not defined.")
+"""
+What does this do
+"""
+function geometry end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,35 @@
 using GeoInterface
 using Test
 
+struct TestPosition{T} <: AbstractPosition{T} 
+
+end
+
 @testset "Comparison operators" begin
+
+    @test coordinates([1.0, 2.0]) == [1.0, 2.0]
+    @test coordinates(Any[1.0, 2.0]) == [1.0, 2.0]
+
+    @test coordinates([1, 2.0]) == [1.0, 2.0]
+    @test coordinates([[1, 2.0]]) == [[1.0, 2.0]]
+    @test coordinates([[[1, 2.0]]]) == [[[1.0, 2.0]]]
+    @test coordinates([[[[1, 2.0]]]]) == [[[[1.0, 2.0]]]]
+
+    @test coordinates(Point([1.0, 2.0])) == [1.0, 2.0]
+    @test coordinates([Point([1.0, 2.0])]) == [[1.0, 2.0]]
+    @test coordinates([[Point([1.0, 2.0])]]) == [[[1.0, 2.0]]]
+    @test coordinates([[[Point([1.0, 2.0])]]]) == [[[[1.0, 2.0]]]]
+
+    Point([1.0, 2.0]) == Point(Any[1.0, 2.0])
+    MultiPoint([[1.0, 2.0]])
+    == 
+    MultiPoint([Any[1.0, 2.0]])
+
+    Polygon([[Point([1.0, 2.0])]])
+    Polygon([[1.0, 2.0]])
+    Polygon([[Any[1.0, 2.0]]])
+    Polygon([[[1, 2.0]]])
+
     # Points are now compared by value:
     pt1, pt2, pt3 = Point([0.0, 0.0]), Point([0.0, 0.0]), Point([0.0, 1.0])
     @test pt1 == pt1


### PR DESCRIPTION
This isn't ready to pull yet, more as a placeholder/reminder that this refactor has been done. 

Merging it is blocked by the GeoJSON test suite. It doesn't handle its own `Any` typed positions and relies on the `Vector{Float64}` type conversion that previously happened in GeoInterface.jl, but really shouldn't. It shouldn't be too much hassle to fix that, I just haven't gotten around to it.

It would also be good if we ran the test suites for dependent packages in the CI for this package.

Edit: its probably worth just waiting and using refactoring to use GeometryTypes now that I've looked into it, I mostly refactored this just to learn the package so its not really wasted effort.