### PR TITLE
Fix plotting for shapefiles with multiple polygons

### DIFF
--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -126,7 +126,7 @@ RecipesBase.@recipe function f(geom::AbstractGeometry)
     shapecoords(geom)
 end
 
-RecipesBase.@recipe function f(geom::Vector{<:AbstractGeometry})
+RecipesBase.@recipe function f(geom::Vector{<:Union{Missing, AbstractGeometry}})
     aspect_ratio := 1
     legend --> :false
     for g in geom


### PR DESCRIPTION
Fixes this case
```julia
using Plots, Shapefile
shp = Shapefile.shapes(Shapefile.Table("IndoPacific_Islands1332.shp"))
plot(shp)
```
Which otherwise failed
