### PR TITLE
generalise crs and bbox to return nothing for any object

### DIFF
--- a/src/GeoInterface.jl
+++ b/src/GeoInterface.jl
@@ -70,15 +70,14 @@ module GeoInterface
     geometry(obj::AbstractFeature) = error("geometry(::AbstractFeature) not defined.")
     # optional
     properties(obj::AbstractFeature) = Dict{String,Any}()
-    bbox(obj::AbstractFeature) = nothing
-    crs(obj::AbstractFeature) = nothing
 
     abstract type AbstractFeatureCollection end
     geotype(::AbstractFeatureCollection) = :FeatureCollection
     features(obj::AbstractFeatureCollection) = error("features(::AbstractFeatureCollection) not defined.")
+
     # optional
-    bbox(obj::AbstractFeatureCollection) = nothing
-    crs(obj::AbstractFeatureCollection) = nothing
+    bbox(obj) = nothing
+    crs(obj) = nothing
 
     include("operations.jl")
     include("geotypes.jl")


### PR DESCRIPTION
This PR simply removes the type specialization from the fallback `crs` and `bbox`, so that they can be called and used on other objects.

-  `crs` can then replace `crs` in GeoData.jl (which returns a `GeoFormatTypes` object)
-  `bbox` can be used on any geometries, as some like shapefile objects have a bounding box attached.