### PR TITLE
only set aspect_ratio on nonmutating calls of plot()

### DIFF
--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -69,63 +69,63 @@ function shapecoords(geom::AbstractGeometry)
 end
 
 RecipesBase.@recipe function f(geom::AbstractPoint)
+    label --> :none
     if plotattributes[:plot_object].n == 0 
         aspect_ratio --> 1
-        legend --> :false
     end
     seriestype --> :scatter
     shapecoords(geom)
 end
 
 RecipesBase.@recipe function f(geom::AbstractMultiPoint)
+    label --> :none
     if plotattributes[:plot_object].n == 0 
         aspect_ratio --> 1
-        legend --> :false
     end
     seriestype --> :scatter
     shapecoords(geom)
 end
 
 RecipesBase.@recipe function f(geom::AbstractLineString)
+    label --> :none
     if plotattributes[:plot_object].n == 0 
         aspect_ratio --> 1
-        legend --> :false
     end
     seriestype --> :path
     shapecoords(geom)
 end
 
 RecipesBase.@recipe function f(geom::AbstractMultiLineString)
+    label --> :none
     if plotattributes[:plot_object].n == 0 
         aspect_ratio --> 1
-        legend --> :false
     end
     seriestype --> :path
     shapecoords(geom)
 end
 
 RecipesBase.@recipe function f(geom::AbstractPolygon)
+    label --> :none
     if plotattributes[:plot_object].n == 0 
         aspect_ratio --> 1
-        legend --> :false
     end
     seriestype --> :shape
     shapecoords(geom)
 end
 
 RecipesBase.@recipe function f(geom::AbstractMultiPolygon)
+    label --> :none
     if plotattributes[:plot_object].n == 0 
         aspect_ratio --> 1
-        legend --> :false
     end
     seriestype --> :shape
     shapecoords(geom)
 end
 
 RecipesBase.@recipe function f(geom::AbstractGeometry)
+    label --> :none
     if plotattributes[:plot_object].n == 0 
         aspect_ratio --> 1
-        legend --> :false
     end
     gtype = geotype(geom)
     if gtype == :Point || gtype == :MultiPoint
@@ -141,9 +141,9 @@ RecipesBase.@recipe function f(geom::AbstractGeometry)
 end
 
 RecipesBase.@recipe function f(geom::Vector{<:Union{Missing, AbstractGeometry}})
+    label --> :none
     if plotattributes[:plot_object].n == 0 
         aspect_ratio --> 1
-        legend --> :false
     end
     for g in skipmissing(geom)
         @series begin

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -68,51 +68,65 @@ function shapecoords(geom::AbstractGeometry)
     end
 end
 
-RecipesBase.@recipe f(geom::AbstractPoint) = (
-    aspect_ratio --> 1;
-    seriestype --> :scatter;
-    legend --> :false;
+RecipesBase.@recipe function f(geom::AbstractPoint)
+    if plotattributes[:plot_object].n == 0 
+        aspect_ratio --> 1
+        legend --> :false
+    end
+    seriestype --> :scatter
     shapecoords(geom)
-)
+end
 
-RecipesBase.@recipe f(geom::AbstractMultiPoint) = (
-    aspect_ratio --> 1;
-    seriestype --> :scatter;
-    legend --> :false;
+RecipesBase.@recipe function f(geom::AbstractMultiPoint)
+    if plotattributes[:plot_object].n == 0 
+        aspect_ratio --> 1
+        legend --> :false
+    end
+    seriestype --> :scatter
     shapecoords(geom)
-)
+end
 
-RecipesBase.@recipe f(geom::AbstractLineString) = (
-    aspect_ratio --> 1;
-    seriestype --> :path;
-    legend --> :false;
+RecipesBase.@recipe function f(geom::AbstractLineString)
+    if plotattributes[:plot_object].n == 0 
+        aspect_ratio --> 1
+        legend --> :false
+    end
+    seriestype --> :path
     shapecoords(geom)
-)
+end
 
-RecipesBase.@recipe f(geom::AbstractMultiLineString) = (
-    aspect_ratio --> 1;
-    seriestype --> :path;
-    legend --> :false;
+RecipesBase.@recipe function f(geom::AbstractMultiLineString)
+    if plotattributes[:plot_object].n == 0 
+        aspect_ratio --> 1
+        legend --> :false
+    end
+    seriestype --> :path
     shapecoords(geom)
-)
+end
 
-RecipesBase.@recipe f(geom::AbstractPolygon) = (
-    aspect_ratio --> 1;
-    seriestype --> :shape;
-    legend --> :false;
+RecipesBase.@recipe function f(geom::AbstractPolygon)
+    if plotattributes[:plot_object].n == 0 
+        aspect_ratio --> 1
+        legend --> :false
+    end
+    seriestype --> :shape
     shapecoords(geom)
-)
+end
 
-RecipesBase.@recipe f(geom::AbstractMultiPolygon) = (
-    aspect_ratio --> 1;
-    seriestype --> :shape;
-    legend --> :false;
+RecipesBase.@recipe function f(geom::AbstractMultiPolygon)
+    if plotattributes[:plot_object].n == 0 
+        aspect_ratio --> 1
+        legend --> :false
+    end
+    seriestype --> :shape
     shapecoords(geom)
-)
+end
 
 RecipesBase.@recipe function f(geom::AbstractGeometry)
-    aspect_ratio --> 1
-    legend --> :false
+    if plotattributes[:plot_object].n == 0 
+        aspect_ratio --> 1
+        legend --> :false
+    end
     gtype = geotype(geom)
     if gtype == :Point || gtype == :MultiPoint
         seriestype := :scatter
@@ -127,8 +141,10 @@ RecipesBase.@recipe function f(geom::AbstractGeometry)
 end
 
 RecipesBase.@recipe function f(geom::Vector{<:Union{Missing, AbstractGeometry}})
-    aspect_ratio --> 1
-    legend --> :false
+    if plotattributes[:plot_object].n == 0 
+        aspect_ratio --> 1
+        legend --> :false
+    end
     for g in skipmissing(geom)
         @series begin
             gtype = geotype(g)


### PR DESCRIPTION
This PR addresses the following issue:

Assume the following code example:
```julia
using GeoInterface, Plots

plot(1:3,1:3, aspect_ratio=2, legend=true)
ls = LineString([[0.,0.],[1.,0.],[1.,1.],[0.,1.], [0.,0.]])
plot!(ls)
```


The mutating call `plot!(ls)` resets the previous set `aspect_ratio` and `legend` arguments to the value defined in the recipe of this package.


This PR changes the above described behavior in the following way:

for `aspect_ratio`:
only set the `aspect_ratio` for the first plot series and not for mutating calls of `plot!()`


for `legend`:

replace `legend --> false` with `label --> :none`

this ensures that there will be no `legend` as long as you only add subtypes of  `AbstractGeometries` without an explicit `label`
