### PR TITLE
add trait based plot recipes in a subpackage

### DIFF
--- a/.github/workflows/recipes.yml
+++ b/.github/workflows/recipes.yml
@@ -1,0 +1,62 @@
+name: GeoInterfaceRecipes CI
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+    branches:
+      - master
+      - breaking-release
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+    branches:
+      - master
+      - breaking-release
+    tags: '*'
+
+concurrency:
+  group: cairomakie-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: GeoInterfaceRecipes Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.6'
+          - '1' # automatically expands to the latest stable 1.x release of Julia
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - name: Install Julia dependencies
+        shell: julia --project=monorepo {0}
+        run: |
+          using Pkg;
+          # dev mono repo versions
+          pkg"dev . ./GeoInterfaceRecipes"
+      - name: Run the tests
+        continue-on-error: true
+        run: >
+          julia --color=yes --project=monorepo -e 'using Pkg; Pkg.test("GeoInterfaceRecipes", coverage=true)'
+          && echo "TESTS_SUCCESSFUL=true" >> $GITHUB_ENV
+      - name: Exit if tests failed
+        if: ${{ env.TESTS_SUCCESSFUL != 'true' }}
+        run: exit 1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/GeoInterfaceRecipes/Project.toml
+++ b/GeoInterfaceRecipes/Project.toml
@@ -4,16 +4,17 @@ authors = ["JuliaGeo and contributors"]
 version = "1.0.0"
 
 [deps]
-RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [compat]
-RecipesBase = "1"
 GeoInterface = "1"
+RecipesBase = "1"
 julia = "1"
 
 [extras]
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Plots", "Test"]

--- a/GeoInterfaceRecipes/Project.toml
+++ b/GeoInterfaceRecipes/Project.toml
@@ -1,0 +1,19 @@
+name = "GeoInterfaceRecipes"
+uuid = "0329782f-3d07-4b52-b9f6-d3137cf03c7a"
+authors = ["JuliaGeo and contributors"]
+version = "1.0.0"
+
+[deps]
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
+
+[compat]
+RecipesBase = "1"
+GeoInterface = "1"
+julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/GeoInterfaceRecipes/README.md
+++ b/GeoInterfaceRecipes/README.md
@@ -1,0 +1,5 @@
+[![Build Status](https://github.com/JuliaGeo/GeoInterface.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/JuliaGeo/GeoInterface.jl/actions/workflows/CI.yml?query=branch%3Amain)
+
+# GeoInterfaceRecipes
+
+Plot recipes for GeoInterface objects, using RecipesBase.jl

--- a/GeoInterfaceRecipes/src/GeoInterfaceRecipes.jl
+++ b/GeoInterfaceRecipes/src/GeoInterfaceRecipes.jl
@@ -19,7 +19,7 @@ macro enable_geo_plots(typ)
               @nospecialize
               series_list = RecipesBase.RecipeData[]
               RecipesBase.is_explicit(plotattributes, :label) || (plotattributes[:label] = :none)
-              Base.push!(series_list, RecipesBase.RecipeData(plotattributes, (GeoInterface.geomtype(geom), geom)))
+              Base.push!(series_list, RecipesBase.RecipeData(plotattributes, (GeoInterface.geomtrait(geom), geom)))
               return series_list
         end
         function RecipesBase.apply_recipe(plotattributes::Base.AbstractDict{Base.Symbol, Base.Any}, geom::Base.AbstractVector{<:Base.Union{Base.Missing,<:($(esc(typ)))}})
@@ -27,7 +27,7 @@ macro enable_geo_plots(typ)
               series_list = RecipesBase.RecipeData[]
               RecipesBase.is_explicit(plotattributes, :label) || (plotattributes[:label] = :none)
               for g in Base.skipmissing(geom)
-                  Base.push!(series_list, RecipesBase.RecipeData(plotattributes, (GeoInterface.geomtype(g), g)))
+                  Base.push!(series_list, RecipesBase.RecipeData(plotattributes, (GeoInterface.geomtrait(g), g)))
               end
               return series_list
         end

--- a/GeoInterfaceRecipes/src/GeoInterfaceRecipes.jl
+++ b/GeoInterfaceRecipes/src/GeoInterfaceRecipes.jl
@@ -1,0 +1,139 @@
+module GeoInterfaceRecipes
+
+using GeoInterface, RecipesBase
+
+const GI = GeoInterface
+
+"""
+     GeoInterfaceRecipes.@enable_geo_plots(typ)
+
+Macro to add plot recipes to a geometry type.
+"""
+macro enable_geo_plots(typ)
+    quote
+        function RecipesBase.apply_recipe(plotattributes::Base.AbstractDict{Base.Symbol, Base.Any}, geom::$(esc(typ)))
+              @nospecialize
+              series_list = RecipesBase.RecipeData[]
+              RecipesBase.is_explicit(plotattributes, :label) || (plotattributes[:label] = :none)
+              Base.push!(series_list, RecipesBase.RecipeData(plotattributes, (GeoInterface.geomtype(geom), geom)))
+              return series_list
+        end
+        function RecipesBase.apply_recipe(plotattributes::Base.AbstractDict{Base.Symbol, Base.Any}, geom::Base.AbstractVector{<:Base.Union{Base.Missing,<:($(esc(typ)))}})
+              @nospecialize
+              series_list = RecipesBase.RecipeData[]
+              RecipesBase.is_explicit(plotattributes, :label) || (plotattributes[:label] = :none)
+              for g in Base.skipmissing(geom)
+                  Base.push!(series_list, RecipesBase.RecipeData(plotattributes, (GeoInterface.geomtype(g), g)))
+              end
+              return series_list
+        end
+    end
+end
+
+RecipesBase.@recipe function f(t::Union{GI.PointTrait,GI.MultiPointTrait}, geom)
+    seriestype --> :scatter
+    _plotvecs(t, geom)
+end
+
+RecipesBase.@recipe function f(t::Union{GI.LineStringTrait,GI.MultiLineStringTrait}, geom)
+    seriestype --> :path
+    _plotvecs(t, geom)
+end
+
+RecipesBase.@recipe function f(t::Union{GI.PolygonTrait,GI.MultiPolygonTrait}, geom)
+    seriestype --> :shape
+    _plotvecs(t, geom)
+end
+
+RecipesBase.@recipe f(::GI.GeometryCollectionTrait, collection) = geometries(collection)
+
+# Convert coordinates to the form used by Plots.jl
+_plotvecs(::GI.PointTrait, geom) = [tuple(GI.coordinates(geom)...)]
+function _plotvecs(::GI.MultiPointTrait, geom)
+    n = GI.npoint(geom)
+    if GI.is3d(geom)
+        _geom2plotvec!(ntuple(_ -> Array{Float64}(undef, n), 3)..., geom)
+    else
+        _geom2plotvec!(ntuple(_ -> Array{Float64}(undef, n), 2)..., geom)
+    end
+end
+function _plotvecs(::GI.LineStringTrait, geom)
+    if GI.is3d(geom)
+        vecs = ntuple(_ -> Array{Float64}(undef, n), 3)
+        return _geom2plotvec!(vecs..., GI.getgeom(geom))
+    else
+        vecs = ntuple(_ -> Array{Float64}(undef, n), 2)
+        return _geom2plotvec!(vecs..., GI.getgeom(geom))
+    end
+end
+function _plotvecs(::GI.MultiLineStringTrait, geom)
+    function loop!(vecs, geom)
+        i1 = 1
+        for line in GI.getgeom(geom)
+            i2 = i1 + GI.npoint(line) - 1
+            vvecs = map(v -> view(v, i1:i2), vecs)
+            _geom2plotvec!(vvecs..., line)
+            map(v -> v[i2 + 1] = NaN, vecs)
+            i1 = i2 + 2
+        end
+        return vecs
+    end
+    n = GI.npoint(geom) + GI.ngeom(geom)
+    if GI.is3d(geom)
+        vecs = ntuple(_ -> Array{Float64}(undef, n), 3)
+        return loop!(vecs, geom)
+    else
+        vecs = ntuple(_ -> Array{Float64}(undef, n), 2)
+        return loop!(vecs, geom)
+    end
+end
+function _plotvecs(::GI.PolygonTrait, geom)
+    ring = first(GI.getgeom(geom)) # currently doesn't plot holes
+    if GI.is3d(geom)
+        return getindex.(ring, 1), getindex.(ring, 2), getindex.(ring, 3)
+    else
+        return first.(ring), last.(ring)
+    end
+end
+function _plotvecs(::GI.MultiPolygonTrait, geom)
+    function loop!(vecs, geom)
+        i1 = 1
+        for ring in GI.getring(geom)
+            i2 = i1 + GI.npoint(ring) - 1
+            range = i1:i2
+            vvecs = map(v -> view(v, range), vecs)
+            _geom2plotvec!(vvecs..., ring)
+            map(v -> v[i2 + 1] = NaN, vecs)
+            i1 = i2 + 2
+        end
+        return vecs
+    end
+    n = GI.npoint(geom) + GI.nring(geom)
+    if GI.is3d(geom)
+        vecs = ntuple(_ -> Array{Float64}(undef, n), 3)
+        return loop!(vecs, geom)
+    else
+        vecs = ntuple(_ -> Array{Float64}(undef, n), 2)
+        return loop!(vecs, geom)
+    end
+end
+
+_plotvec(n) = Array{Float64}(undef, n)
+
+function _geom2plotvec!(xs, ys, geom)
+    for (i, p) in enumerate(GI.getpoint(geom))
+        xs[i] = GI.x(p)
+        ys[i] = GI.y(p)
+    end
+    return xs, ys
+end
+function _geom2plotvec!(xs, ys, zs, geom)
+    for (i, p) in enumerate(GI.getpoint(geom))
+        xs[i] = GI.x(p)
+        ys[i] = GI.y(p)
+        zs[i] = GI.z(p)
+    end
+    return xs, ys, zs
+end
+
+end

--- a/GeoInterfaceRecipes/test/runtests.jl
+++ b/GeoInterfaceRecipes/test/runtests.jl
@@ -17,36 +17,36 @@ struct MyCollection{N} <: MyAbstractGeom{N} end
 GeoInterfaceRecipes.@enable_geo_plots MyAbstractGeom
 
 GeoInterface.isgeometry(::MyAbstractGeom) = true
-GeoInterface.is3d(::GeoInterface.AbstractGeometryTrait, ::MyAbstractGeom{N}) where N = N == 3
-GeoInterface.ncoord(::GeoInterface.AbstractGeometryTrait, geom::MyAbstractGeom{N}) where N = N
+GeoInterface.is3d(::GeoInterface.AbstractGeometryTrait, ::MyAbstractGeom{N}) where {N} = N == 3
+GeoInterface.ncoord(::GeoInterface.AbstractGeometryTrait, geom::MyAbstractGeom{N}) where {N} = N
 GeoInterface.coordnames(::GeoInterface.AbstractGeometryTrait, ::MyAbstractGeom{2}) = (:X, :Y)
 GeoInterface.coordnames(::GeoInterface.AbstractGeometryTrait, ::MyAbstractGeom{3}) = (:X, :Y, :Z)
 
-GeoInterface.geomtype(::MyPoint) = GeoInterface.PointTrait()
+GeoInterface.geomtrait(::MyPoint) = GeoInterface.PointTrait()
 GeoInterface.getcoord(::GeoInterface.PointTrait, geom::MyPoint{2}, i::Integer) = (rand(1:10), rand(11:20))[i]
 GeoInterface.getcoord(::GeoInterface.PointTrait, geom::MyPoint{3}, i::Integer) = (rand(1:10), rand(11:20), rand(21:30))[i]
 
-GeoInterface.geomtype(::MyCurve) = GeoInterface.LineStringTrait()
+GeoInterface.geomtrait(::MyCurve) = GeoInterface.LineStringTrait()
 GeoInterface.ngeom(::GeoInterface.LineStringTrait, geom::MyCurve) = 3
-GeoInterface.getgeom(::GeoInterface.LineStringTrait, geom::MyCurve{N}, i) where N = MyPoint{N}()
+GeoInterface.getgeom(::GeoInterface.LineStringTrait, geom::MyCurve{N}, i) where {N} = MyPoint{N}()
 GeoInterface.convert(::Type{MyCurve}, ::GeoInterface.LineStringTrait, geom) = geom
 
-GeoInterface.geomtype(::MyPolygon) = GeoInterface.PolygonTrait()
+GeoInterface.geomtrait(::MyPolygon) = GeoInterface.PolygonTrait()
 GeoInterface.ngeom(::GeoInterface.PolygonTrait, geom::MyPolygon) = 2
-GeoInterface.getgeom(::GeoInterface.PolygonTrait, geom::MyPolygon{N}, i) where N = MyCurve{N}()
+GeoInterface.getgeom(::GeoInterface.PolygonTrait, geom::MyPolygon{N}, i) where {N} = MyCurve{N}()
 
-GeoInterface.geomtype(::MyMultiPolygon) = GeoInterface.MultiPolygonTrait()
+GeoInterface.geomtrait(::MyMultiPolygon) = GeoInterface.MultiPolygonTrait()
 GeoInterface.ngeom(::GeoInterface.MultiPolygonTrait, geom::MyMultiPolygon) = 2
-GeoInterface.getgeom(::GeoInterface.MultiPolygonTrait, geom::MyMultiPolygon{N}, i) where N = MyPolygon{N}()
+GeoInterface.getgeom(::GeoInterface.MultiPolygonTrait, geom::MyMultiPolygon{N}, i) where {N} = MyPolygon{N}()
 
-GeoInterface.geomtype(::MyMultiPoint) = GeoInterface.MultiPointTrait()
+GeoInterface.geomtrait(::MyMultiPoint) = GeoInterface.MultiPointTrait()
 GeoInterface.ngeom(::GeoInterface.MultiPointTrait, geom::MyMultiPoint) = 10
-GeoInterface.getgeom(::GeoInterface.MultiPointTrait, geom::MyMultiPoint{N}, i) where N = MyPoint{N}()
+GeoInterface.getgeom(::GeoInterface.MultiPointTrait, geom::MyMultiPoint{N}, i) where {N} = MyPoint{N}()
 
-GeoInterface.geomtype(geom::MyCollection) = GeoInterface.GeometryCollectionTrait()
-GeoInterface.ncoord(::GeoInterface.GeometryCollectionTrait, geom::MyCollection{N}) where N = N
+GeoInterface.geomtrait(geom::MyCollection) = GeoInterface.GeometryCollectionTrait()
+GeoInterface.ncoord(::GeoInterface.GeometryCollectionTrait, geom::MyCollection{N}) where {N} = N
 GeoInterface.ngeom(::GeoInterface.GeometryCollectionTrait, geom::MyCollection) = 4
-GeoInterface.getgeom(::GeoInterface.GeometryCollectionTrait, geom::MyCollection{N}, i) where N = MyMultiPolygon{N}()
+GeoInterface.getgeom(::GeoInterface.GeometryCollectionTrait, geom::MyCollection{N}, i) where {N} = MyMultiPolygon{N}()
 
 @testset "plot" begin
     # We just check if they actually run

--- a/GeoInterfaceRecipes/test/runtests.jl
+++ b/GeoInterfaceRecipes/test/runtests.jl
@@ -1,0 +1,3 @@
+using GeoInterfaceRecipes
+using GeoInterface
+using Test

--- a/GeoInterfaceRecipes/test/runtests.jl
+++ b/GeoInterfaceRecipes/test/runtests.jl
@@ -1,3 +1,67 @@
 using GeoInterfaceRecipes
 using GeoInterface
+using Plots
 using Test
+
+
+abstract type MyAbstractGeom{N} end
+# Implement interface
+struct MyPoint{N} <: MyAbstractGeom{N} end
+struct MyCurve{N} <: MyAbstractGeom{N} end
+struct MyPolygon{N} <: MyAbstractGeom{N} end
+struct MyMultiPoint{N} <: MyAbstractGeom{N} end
+struct MyMultiCurve{N} <: MyAbstractGeom{N} end
+struct MyMultiPolygon{N} <: MyAbstractGeom{N} end
+struct MyCollection{N} <: MyAbstractGeom{N} end
+
+GeoInterfaceRecipes.@enable_geo_plots MyAbstractGeom
+
+GeoInterface.isgeometry(::MyAbstractGeom) = true
+GeoInterface.is3d(::GeoInterface.AbstractGeometryTrait, ::MyAbstractGeom{N}) where N = N == 3
+GeoInterface.ncoord(::GeoInterface.AbstractGeometryTrait, geom::MyAbstractGeom{N}) where N = N
+GeoInterface.coordnames(::GeoInterface.AbstractGeometryTrait, ::MyAbstractGeom{2}) = (:X, :Y)
+GeoInterface.coordnames(::GeoInterface.AbstractGeometryTrait, ::MyAbstractGeom{3}) = (:X, :Y, :Z)
+
+GeoInterface.geomtype(::MyPoint) = GeoInterface.PointTrait()
+GeoInterface.getcoord(::GeoInterface.PointTrait, geom::MyPoint{2}, i::Integer) = (rand(1:10), rand(11:20))[i]
+GeoInterface.getcoord(::GeoInterface.PointTrait, geom::MyPoint{3}, i::Integer) = (rand(1:10), rand(11:20), rand(21:30))[i]
+
+GeoInterface.geomtype(::MyCurve) = GeoInterface.LineStringTrait()
+GeoInterface.ngeom(::GeoInterface.LineStringTrait, geom::MyCurve) = 3
+GeoInterface.getgeom(::GeoInterface.LineStringTrait, geom::MyCurve{N}, i) where N = MyPoint{N}()
+GeoInterface.convert(::Type{MyCurve}, ::GeoInterface.LineStringTrait, geom) = geom
+
+GeoInterface.geomtype(::MyPolygon) = GeoInterface.PolygonTrait()
+GeoInterface.ngeom(::GeoInterface.PolygonTrait, geom::MyPolygon) = 2
+GeoInterface.getgeom(::GeoInterface.PolygonTrait, geom::MyPolygon{N}, i) where N = MyCurve{N}()
+
+GeoInterface.geomtype(::MyMultiPolygon) = GeoInterface.MultiPolygonTrait()
+GeoInterface.ngeom(::GeoInterface.MultiPolygonTrait, geom::MyMultiPolygon) = 2
+GeoInterface.getgeom(::GeoInterface.MultiPolygonTrait, geom::MyMultiPolygon{N}, i) where N = MyPolygon{N}()
+
+GeoInterface.geomtype(::MyMultiPoint) = GeoInterface.MultiPointTrait()
+GeoInterface.ngeom(::GeoInterface.MultiPointTrait, geom::MyMultiPoint) = 10
+GeoInterface.getgeom(::GeoInterface.MultiPointTrait, geom::MyMultiPoint{N}, i) where N = MyPoint{N}()
+
+GeoInterface.geomtype(geom::MyCollection) = GeoInterface.GeometryCollectionTrait()
+GeoInterface.ncoord(::GeoInterface.GeometryCollectionTrait, geom::MyCollection{N}) where N = N
+GeoInterface.ngeom(::GeoInterface.GeometryCollectionTrait, geom::MyCollection) = 4
+GeoInterface.getgeom(::GeoInterface.GeometryCollectionTrait, geom::MyCollection{N}, i) where N = MyMultiPolygon{N}()
+
+@testset "plot" begin
+    # We just check if they actually run
+    # 2d
+    plot(MyPoint{2}())
+    plot(MyCurve{2}())
+    plot(MyMultiPoint{2}())
+    plot(MyPolygon{2}())
+    plot(MyMultiPolygon{2}())
+    plot(MyCollection{2}())
+    # 3d
+    plot(MyPoint{3}())
+    plot(MyCurve{3}())
+    plot(MyMultiPoint{3}())
+    plot(MyPolygon{3}())
+    plot(MyMultiPolygon{3}())
+    plot(MyCollection{3}())
+end


### PR DESCRIPTION
This PR adds plot recipes back to the interface, but using the traits. Its actually a lot simpler with traits.

To work automatically on e.g. Shapefile.jl and ArchGDAL.jl objects, we still need them to inherit from something we can dispatch on here. So I've added back the `AbstractGeometry` type as an entry point to things like this where packages want that. 

Packages that don't inherit from this can still use these plot recipes, but will need to add a RecipesBase dependency, and methods like this:

```julia
using RecipesBase
@recipe f(geom::AbstractPackageGeom) = GeoInterface.geomtype(geom), geom
@recipe @recipe function f(geom::Vector{<:Union{Missing,AbstractGeometry}})
    for g in skipmissing(geom)
        @series begin
            GeoInterface.geomtype(g), g
        end
    end
end
```


Edit: an alternative to merging this is making a GeoInterfaceRecipes.jl package that packages that need it can depend on, like Shapefiles/ArchGDAL