### PR TITLE
add getpolygons and getrings functions

### DIFF
--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -50,7 +50,7 @@ getpolygon(p::AbstractMultiPolygonTrait, geom) = getgeom(p, geom)
 getpolygon(p::AbstractMultiPolygonTrait, geom, i) = getgeom(p, geom, i)
 getring(g::AbstractMultiPolygonTrait, geom) = (r for r in getring(p) for p in getpolygon(geom))
 getpoint(g::AbstractMultiPolygonTrait, geom) = (p for p in getpoint(r) for r in getring(geom))
-nring(p::AbstractPolygonTrait, geom) = sum(nring(p) for p in getpolygon(p))
+nring(p::AbstractMultiPolygonTrait, geom) = sum(nring(p) for p in getpolygon(p))
 
 ## Surface
 npatch(p::AbstractPolyHedralSurfaceTrait, geom)::Integer = ngeom(p, geom)

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -30,27 +30,31 @@ getpoint(c::AbstractCurveTrait, geom, i) = getgeom(c, geom, i)
 startpoint(c::AbstractCurveTrait, geom) = getpoint(c, geom, 1)
 endpoint(c::AbstractCurveTrait, geom) = getpoint(c, geom, length(geom))
 
-## MultiLineString
-nlinestring(p::AbstractMultiLineStringTrait, geom) = ngeom(p, geom)
-getlinestring(p::AbstractMultiLineStringTrait, geom) = getgeom(p, geom)
-getlinestring(p::AbstractMultiLineStringTrait, geom, i) = getgeom(p, geom, i)
-getpoint(g::AbstractMultiLineStringTrait, geom) = (p for p in getpoint(p) for g in getlinestring(geom))
-
 ## Polygons
 nring(p::AbstractPolygonTrait, geom) = ngeom(p, geom)
 getring(p::AbstractPolygonTrait, geom) = getgeom(p, geom)
 getring(p::AbstractPolygonTrait, geom, i) = getgeom(p, geom, i)
 getexterior(p::AbstractPolygonTrait, geom) = getring(p, geom, 1)
-nhole(p::AbstractPolygonTrait, geom) = nring(p, geom) - 1ring
+nhole(p::AbstractPolygonTrait, geom) = nring(p, geom) - 1
 gethole(p::AbstractPolygonTrait, geom, i) = getring(p, geom, i + 1)
+npoint(p::AbstractPolygonTrait, geom) = sum(npoint(p) for p in getring(p))
+getpoint(g::AbstractPolygonTrait, geom) = (p for p in getpoint(r) for r in getring(geom))
+
+## MultiLineString
+nlinestring(p::AbstractMultiLineStringTrait, geom) = ngeom(p, geom)
+getlinestring(p::AbstractMultiLineStringTrait, geom) = getgeom(p, geom)
+getlinestring(p::AbstractMultiLineStringTrait, geom, i) = getgeom(p, geom, i)
+npoint(g::AbstractMultiLineStringTrait, geom) = sum(npoint(l) for ls in getlinestring(geom))
+getpoint(g::AbstractMultiLineStringTrait, geom) = (p for p in getpoint(ls) for l in getlinestring(geom))
 
 ## MultiPolygon
 npolygon(p::AbstractMultiPolygonTrait, geom) = ngeom(p, geom)
 getpolygon(p::AbstractMultiPolygonTrait, geom) = getgeom(p, geom)
 getpolygon(p::AbstractMultiPolygonTrait, geom, i) = getgeom(p, geom, i)
-getring(g::AbstractMultiPolygonTrait, geom) = (r for r in getring(p) for p in getpolygon(geom))
-getpoint(g::AbstractMultiPolygonTrait, geom) = (p for p in getpoint(r) for r in getring(geom))
 nring(p::AbstractMultiPolygonTrait, geom) = sum(nring(p) for p in getpolygon(p))
+getring(g::AbstractMultiPolygonTrait, geom) = (r for r in getring(p) for p in getpolygon(geom))
+npoint(p::AbstractMultiPolygonTrait, geom) = sum(npoint(r) for r in getring(geom))
+getpoint(g::AbstractMultiPolygonTrait, geom) = (p for p in getpoint(r) for r in getring(geom))
 
 ## Surface
 npatch(p::AbstractPolyHedralSurfaceTrait, geom)::Integer = ngeom(p, geom)

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -48,9 +48,9 @@ gethole(p::AbstractPolygonTrait, geom, i) = getring(p, geom, i + 1)
 npolygon(p::AbstractMultiPolygonTrait, geom) = ngeom(p, geom)
 getpolygon(p::AbstractMultiPolygonTrait, geom) = getgeom(p, geom)
 getpolygon(p::AbstractMultiPolygonTrait, geom, i) = getgeom(p, geom, i)
-getring(g::AbstractMultiPolygonTrait, geom) = (r for r in getrings(p) for p in getpolygons(geom))
+getring(g::AbstractMultiPolygonTrait, geom) = (r for r in getring(p) for p in getpolygon(geom))
 getpoint(g::AbstractMultiPolygonTrait, geom) = (p for p in getpoint(r) for r in getring(geom))
-nring(p::AbstractPolygonTrait, geom) = sum(nring(p) for p in getpolygons(p))
+nring(p::AbstractPolygonTrait, geom) = sum(nring(p) for p in getpolygon(p))
 
 ## Surface
 npatch(p::AbstractPolyHedralSurfaceTrait, geom)::Integer = ngeom(p, geom)

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -30,24 +30,26 @@ getpoint(c::AbstractCurveTrait, geom, i) = getgeom(c, geom, i)
 startpoint(c::AbstractCurveTrait, geom) = getpoint(c, geom, 1)
 endpoint(c::AbstractCurveTrait, geom) = getpoint(c, geom, length(geom))
 
+## MultiLineString
+nlinestring(p::AbstractMultiLineStringTrait, geom) = ngeom(p, geom)
+getlinestring(p::AbstractMultiLineStringTrait, geom) = getgeom(p, geom)
+getlinestring(p::AbstractMultiLineStringTrait, geom, i) = getgeom(p, geom, i)
+getpoint(g::AbstractMultiLineStringTrait, geom) = (p for p in getpoint(p) for g in getlinestring(geom))
+
 ## Polygons
 nring(p::AbstractPolygonTrait, geom) = ngeom(p, geom)
 getring(p::AbstractPolygonTrait, geom) = getgeom(p, geom)
 getring(p::AbstractPolygonTrait, geom, i) = getgeom(p, geom, i)
 getexterior(p::AbstractPolygonTrait, geom) = getring(p, geom, 1)
-nhole(p::AbstractPolygonTrait, geom) = nring(p, geom) - 1
+nhole(p::AbstractPolygonTrait, geom) = nring(p, geom) - 1ring
 gethole(p::AbstractPolygonTrait, geom, i) = getring(p, geom, i + 1)
-
-## MultiLineString
-nlinestring(p::AbstractMultiLineStringTrait, geom) = ngeom(p, geom)
-getlinestring(p::AbstractMultiLineStringTrait, geom) = getgeom(p, geom)
-getlinestring(p::AbstractMultiLineStringTrait, geom, i) = getgeom(p, geom, i)
 
 ## MultiPolygon
 npolygon(p::AbstractMultiPolygonTrait, geom) = ngeom(p, geom)
 getpolygon(p::AbstractMultiPolygonTrait, geom) = getgeom(p, geom)
 getpolygon(p::AbstractMultiPolygonTrait, geom, i) = getgeom(p, geom, i)
 getring(g::AbstractMultiPolygonTrait, geom) = (r for r in getrings(p) for p in getpolygons(geom))
+getpoint(g::AbstractMultiPolygonTrait, geom) = (p for p in getpoint(r) for r in getring(geom))
 nring(p::AbstractPolygonTrait, geom) = sum(nring(p) for p in getpolygons(p))
 
 ## Surface

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -47,6 +47,8 @@ getlinestring(p::AbstractMultiLineStringTrait, geom, i) = getgeom(p, geom, i)
 npolygon(p::AbstractMultiPolygonTrait, geom) = ngeom(p, geom)
 getpolygon(p::AbstractMultiPolygonTrait, geom) = getgeom(p, geom)
 getpolygon(p::AbstractMultiPolygonTrait, geom, i) = getgeom(p, geom, i)
+getring(g::AbstractMultiPolygonTrait, geom) = (r for r in getrings(p) for p in getpolygons(geom))
+nring(p::AbstractPolygonTrait, geom) = sum(nring(p) for p in getpolygons(p))
 
 ## Surface
 npatch(p::AbstractPolyHedralSurfaceTrait, geom)::Integer = ngeom(p, geom)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -84,7 +84,7 @@ Note that this is only valid for individual [`AbstractPoint`]s.
 """
 getcoord(geom, i::Integer) = getcoord(geomtype(geom), geom, i)
 """
-    getcoord(geom) -> Iterator
+    getcoord(geom) -> iterator
 """
 getcoord(geom) = getcoord(geomtype(geom), geom)
 
@@ -104,8 +104,11 @@ Return the `i`th Point in given `geom`.
 Note that this is only valid for [`AbstractCurve`](@ref)s and [`AbstractMultiPoint`](@ref)s.
 """
 getpoint(geom, i::Integer) = getpoint(geomtype(geom), geom, i)
+
 """
-    getpoint(geom) -> Iterator
+    getpoint(geom) -> iterator
+
+Returns an iterator over all points in `geom`.
 """
 getpoint(geom) = getpoint(geomtype(geom), geom)
 
@@ -200,17 +203,20 @@ nring(geom) = nring(geomtype(geom), geom)
     getring(geom, [i::Integer]) -> Int
 
 Return the `i`th ring for a given `geom`.
-Without the `i` argument, an iterator over all rings is returned.
+
+Note that this is only valid for [`AbstractPolygon`](@ref)s.
+"""
+getring(geom, i::Integer) = getring(geomtype(geom), geom, i)
+
+"""
+    getring(geom) -> iterator
+
+Returns an iterator over all rings in `geom`.
 
 Note that this is only valid for [`AbstractPolygon`](@ref)s and
 [`AbstractMultiPolygon`](@ref)s in single-argument form.
 """
-getring(geom, i::Integer) = getring(geomtype(geom), geom, i)
-"""
-    getring(geom) -> Iterator
-"""
 getring(geom) = getring(geomtype(geom), geom)
-getring(geom, i) = getring(geomtype(geom), geom, i)
 
 """
     getexterior(geom) -> Curve
@@ -220,7 +226,6 @@ Note that this is only valid for [`AbstractPolygon`](@ref)s.
 """
 getexterior(geom) = getexterior(geomtype(geom), geom)
 
-
 """
     nhole(geom) -> Integer
 
@@ -228,6 +233,7 @@ Returns the number of holes for this given `geom`.
 Note that this is only valid for [`AbstractPolygon`](@ref)s.
 """
 nhole(geom)::Integer = nhole(geomtype(geom), geom)
+
 """
     gethole(geom, i::Integer) -> Curve
 
@@ -235,8 +241,12 @@ Returns the `i`th interior ring for this given `geom`.
 Note that this is only valid for [`AbstractPolygon`](@ref)s.
 """
 gethole(geom, i::Integer) = gethole(geomtype(geom), geom, i)
+
 """
-    gethole(geom) -> Iterator
+    gethole(geom) -> iterator
+
+Returns an iterator over all holes in `geom`.
+Note that this is only valid for [`AbstractPolygon`](@ref)s.
 """
 gethole(geom) = gethole(geomtype(geom), geom)
 
@@ -256,8 +266,12 @@ Returns the `i`th patch for the given `geom`.
 Note that this is only valid for [`AbstractPolyHedralSurface`](@ref)s.
 """
 getpatch(geom, i::Integer) = getpatch(geomtype(geom), geom, i)
+
 """
-    getpatch(geom) -> Iterator
+    getpatch(geom) -> iterator
+
+Returns an iterator over all patches in `geom`.
+Note that this is only valid for [`AbstractPolyHedralSurface`](@ref)s.
 """
 getpatch(geom) = getpatch(geomtype(geom), geom)
 
@@ -282,8 +296,11 @@ ngeom(geom) = ngeom(geomtype(geom), geom)
 Returns the `i`th geometry for the given `geom`.
 """
 getgeom(geom, i::Integer) = getgeom(geomtype(geom), geom, i)
+
 """
-    getgeom(geom) -> Iterator
+    getgeom(geom) -> iterator
+
+Returns an iterator over all geometry components in `geom`.
 """
 getgeom(geom) = getgeom(geomtype(geom), geom)
 
@@ -303,8 +320,12 @@ Returns the `i`th linestring for the given `geom`.
 Note that this is only valid for [`AbstractMultiLineString`](@ref)s.
 """
 getlinestring(geom, i::Integer) = getlinestring(geomtype(geom), geom, i)
+
 """
-    getlinestring(geom) -> Iterator
+    getlinestring(geom, i::Integer) -> iterator
+
+Returns an iterator over all linestrings in a geometry.
+Note that this is only valid for [`AbstractMultiLineString`](@ref)s.
 """
 getlinestring(geom) = getlinestring(geomtype(geom), geom)
 
@@ -318,30 +339,38 @@ Note that this is only valid for [`AbstractMultiPolygon`](@ref)s.
 npolygon(geom) = npolygon(geomtype(geom), geom)
 
 """
-    getpolygon(geom, [i::Integer]) -> AbstractCurve
+    getpolygon(geom) -> AbstractCurve
 
 Returns the `i`th polygon for the given `geom`.
-Where no `i` index is passed, an iterator over all polygons is returned.
 Note that this is only valid for [`AbstractMultiPolygon`](@ref)s.
 """
 getpolygon(geom) = getpolygon(geomtype(geom), geom)
-getpolygon(geom, i::Integer) = getpolygon(geomtype(geom), geom, i)
-"""
-    getpolygon(geom) -> Iterator
-"""
-getpolygon(geom) = getpolygon(geomtype(geom), geom)
 
 """
-    getring(geom, i::Integer) -> iterable
+    getpolygon(geom) -> AbstractCurve
+
+Returns an iterator over all polygons in a geometry.
+Note that this is only valid for [`AbstractMultiPolygon`](@ref)s.
+"""
+getpolygon(geom, i::Integer) = getpolygon(geomtype(geom), geom, i)
+
+"""
+    getring(geom, i::Integer) -> AbstractCurve
 
 A specific ring `i` in a polygon or multipolygon (exterior and holes).
-Where no `i` index is passed, an iterator over all rings is returned.
+Note that this is only valid for [`AbstractPolygon`](@ref)s and
+[`AbstractMultiPolygon`](@ref)s.
+"""
+getring(geom, i::Integer) = getring(geomtype(geom), geom, i)
 
+"""
+    getring(geom) -> iterable
+
+Returns an iterator over all rings in a geometry.
 Note that this is only valid for [`AbstractPolygon`](@ref)s and
 [`AbstractMultiPolygon`](@ref)s.
 """
 getring(geom) = getring(geomtype(geom), geom)
-getring(geom, i::Integer) = getring(geomtype(geom), geom, i)
 
 # Other methods
 """
@@ -471,7 +500,7 @@ union(a, b) = union(geomtype(a), geomtype(b), a, b)
 
 # Spatial analysis
 """
-    distance(a, b) -> Number
+3   distance(a, b) -> Number
 
 Returns the shortest distance between `a` with `b`.
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -191,21 +191,26 @@ boundary(geom) = boundary(geomtype(geom), geom)
     nring(geom) -> Integer
 
 Return the number of rings in given `geom`.
-Note that this is only valid for [`AbstractPolygon`](@ref)s.
+Note that this is only valid for [`AbstractPolygon`](@ref)s and
+[`AbstractMultiPolygon`](@ref)s
 """
 nring(geom) = nring(geomtype(geom), geom)
 
 """
-    getring(geom, i::Integer) -> Int
+    getring(geom, [i::Integer]) -> Int
 
 Return the `i`th ring for a given `geom`.
-Note that this is only valid for [`AbstractPolygon`](@ref)s.
+Without the `i` argument, an iterator over all rings is returned.
+
+Note that this is only valid for [`AbstractPolygon`](@ref)s and
+[`AbstractMultiPolygon`](@ref)s in single-argument form.
 """
 getring(geom, i::Integer) = getring(geomtype(geom), geom, i)
 """
     getring(geom) -> Iterator
 """
 getring(geom) = getring(geomtype(geom), geom)
+getring(geom, i) = getring(geomtype(geom), geom, i)
 
 """
     getexterior(geom) -> Curve
@@ -313,16 +318,30 @@ Note that this is only valid for [`AbstractMultiPolygon`](@ref)s.
 npolygon(geom) = npolygon(geomtype(geom), geom)
 
 """
-    getpolygon(geom, i::Integer) -> AbstractCurve
+    getpolygon(geom, [i::Integer]) -> AbstractCurve
 
 Returns the `i`th polygon for the given `geom`.
+Where no `i` index is passed, an iterator over all polygons is returned.
 Note that this is only valid for [`AbstractMultiPolygon`](@ref)s.
 """
+getpolygon(geom) = getpolygon(geomtype(geom), geom)
 getpolygon(geom, i::Integer) = getpolygon(geomtype(geom), geom, i)
 """
     getpolygon(geom) -> Iterator
 """
 getpolygon(geom) = getpolygon(geomtype(geom), geom)
+
+"""
+    getring(geom, i::Integer) -> iterable
+
+A specific ring `i` in a polygon or multipolygon (exterior and holes).
+Where no `i` index is passed, an iterator over all rings is returned.
+
+Note that this is only valid for [`AbstractPolygon`](@ref)s and
+[`AbstractMultiPolygon`](@ref)s.
+"""
+getring(geom) = getring(geomtype(geom), geom)
+getring(geom, i::Integer) = getring(geomtype(geom), geom, i)
 
 # Other methods
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -200,7 +200,7 @@ Note that this is only valid for [`AbstractPolygon`](@ref)s and
 nring(geom) = nring(geomtype(geom), geom)
 
 """
-    getring(geom, [i::Integer]) -> Int
+    getring(geom, i::Integer) -> Int
 
 Return the `i`th ring for a given `geom`.
 
@@ -212,7 +212,6 @@ getring(geom, i::Integer) = getring(geomtype(geom), geom, i)
     getring(geom) -> iterator
 
 Returns an iterator over all rings in `geom`.
-
 Note that this is only valid for [`AbstractPolygon`](@ref)s and
 [`AbstractMultiPolygon`](@ref)s in single-argument form.
 """
@@ -322,7 +321,7 @@ Note that this is only valid for [`AbstractMultiLineString`](@ref)s.
 getlinestring(geom, i::Integer) = getlinestring(geomtype(geom), geom, i)
 
 """
-    getlinestring(geom, i::Integer) -> iterator
+    getlinestring(geom) -> iterator
 
 Returns an iterator over all linestrings in a geometry.
 Note that this is only valid for [`AbstractMultiLineString`](@ref)s.
@@ -339,20 +338,20 @@ Note that this is only valid for [`AbstractMultiPolygon`](@ref)s.
 npolygon(geom) = npolygon(geomtype(geom), geom)
 
 """
-    getpolygon(geom) -> AbstractCurve
+    getpolygon(geom, i::Integer) -> AbstractCurve
 
 Returns the `i`th polygon for the given `geom`.
 Note that this is only valid for [`AbstractMultiPolygon`](@ref)s.
 """
-getpolygon(geom) = getpolygon(geomtype(geom), geom)
+getpolygon(geom, i::Integer) = getpolygon(geomtype(geom), geom, i)
 
 """
-    getpolygon(geom) -> AbstractCurve
+    getpolygon(geom) -> iterator
 
 Returns an iterator over all polygons in a geometry.
 Note that this is only valid for [`AbstractMultiPolygon`](@ref)s.
 """
-getpolygon(geom, i::Integer) = getpolygon(geomtype(geom), geom, i)
+getpolygon(geom) = getpolygon(geomtype(geom), geom)
 
 """
     getring(geom, i::Integer) -> AbstractCurve
@@ -500,7 +499,7 @@ union(a, b) = union(geomtype(a), geomtype(b), a, b)
 
 # Spatial analysis
 """
-3   distance(a, b) -> Number
+    distance(a, b) -> Number
 
 Returns the shortest distance between `a` with `b`.
 """


### PR DESCRIPTION
This PR adds `getpolygons` and `getrings` functions to allow efficient access to all poylgons and rings in cases like Shapefile.jl where exterior and holes are not clearly separated in the spec. Packages like Rasters.jl don't actually care if they are separated so loading them all directly is much more efficient. 

The fallback is to iterate over all polygons and rings.