### PR TITLE
export the traits

### DIFF
--- a/docs/src/guides/developer.md
+++ b/docs/src/guides/developer.md
@@ -15,7 +15,7 @@ Last but not least, we also provide an interface for features--geometries with p
 
 ```julia
 GeoInterface.isgeometry(geom::customgeom)::Bool = true
-GeoInterface.geomtype(geom::customgeom)::DataType = GeoInterface.XTrait() # <: AbstractGeometryTrait
+GeoInterface.geomtype(geom::customgeom)::DataType = XTrait() # <: AbstractGeometryTrait
 # for PointTraits
 GeoInterface.ncoord(geomtype(geom), geom::customgeom)::Integer
 GeoInterface.getcoord(geomtype(geom), geom::customgeom, i)::Real
@@ -93,79 +93,79 @@ GeoInterface.isgeometry(geom::customgeom)::Bool = true
 
 A `geom::customgeom` with "Point"-like traits implements
 ```julia
-GeoInterface.geomtype(geom::customgeom)::DataType = GeoInterface.PointTrait()
-GeoInterface.ncoord(::GeoInterface.PointTrait, geom::customgeom)::Integer
-GeoInterface.getcoord(::GeoInterface.PointTrait, geom::customgeom, i)::Real
+GeoInterface.geomtype(geom::customgeom)::DataType = PointTrait()
+GeoInterface.ncoord(::PointTrait, geom::customgeom)::Integer
+GeoInterface.getcoord(::PointTrait, geom::customgeom, i)::Real
 
 # Defaults
-GeoInterface.ngeom(::GeoInterface.PointTrait, geom)::Integer = 0
-GeoInterface.getgeom(::GeoInterface.PointTrait, geom::customgeom, i) = nothing
+GeoInterface.ngeom(::PointTrait, geom)::Integer = 0
+GeoInterface.getgeom(::PointTrait, geom::customgeom, i) = nothing
 ```
 
 A `geom::customgeom` with "LineString"-like traits implements the following methods:
 ```julia
-GeoInterface.geomtype(geom::customgeom)::DataType = GeoInterface.LineStringTrait()
-GeoInterface.ncoord(::GeoInterface.LineStringTrait, geom::customgeom)::Integer
+GeoInterface.geomtype(geom::customgeom)::DataType = LineStringTrait()
+GeoInterface.ncoord(::LineStringTrait, geom::customgeom)::Integer
 
 # These alias for npoint and getpoint
-GeoInterface.ngeom(::GeoInterface.LineStringTrait, geom::customgeom)::Integer
-GeoInterface.getgeom(::GeoInterface.LineStringTrait, geom::customgeom, i) # of geomtype Point
+GeoInterface.ngeom(::LineStringTrait, geom::customgeom)::Integer
+GeoInterface.getgeom(::LineStringTrait, geom::customgeom, i) # of geomtype Point
 
 # Optional
-GeoInterface.isclosed(::GeoInterface.LineStringTrait, geom::customgeom)::Bool
-GeoInterface.issimple(::GeoInterface.LineStringTrait, geom::customgeom)::Bool
-GeoInterface.length(::GeoInterface.LineStringTrait, geom::customgeom)::Real
+GeoInterface.isclosed(::LineStringTrait, geom::customgeom)::Bool
+GeoInterface.issimple(::LineStringTrait, geom::customgeom)::Bool
+GeoInterface.length(::LineStringTrait, geom::customgeom)::Real
 ```
 A `geom::customgeom` with "Polygon"-like traits can implement the following methods:
 ```julia
-GeoInterface.geomtype(geom::customgeom)::DataType = GeoInterface.PolygonTrait()
-GeoInterface.ncoord(::GeoInterface.PolygonTrait, geom::customgeom)::Integer
+GeoInterface.geomtype(geom::customgeom)::DataType = PolygonTrait()
+GeoInterface.ncoord(::PolygonTrait, geom::customgeom)::Integer
 
 # These alias for nring and getring
-GeoInterface.ngeom(::GeoInterface.PolygonTrait, geom::customgeom)::Integer
-GeoInterface.getgeom(::GeoInterface.PolygonTrait, geom::customgeom, i)::"LineStringTrait"
+GeoInterface.ngeom(::PolygonTrait, geom::customgeom)::Integer
+GeoInterface.getgeom(::PolygonTrait, geom::customgeom, i)::"LineStringTrait"
 
 # Optional
-GeoInterface.area(::GeoInterface.PolygonTrait, geom::customgeom)::Real
-GeoInterface.centroid(::GeoInterface.PolygonTrait, geom::customgeom)::"PointTrait"
-GeoInterface.pointonsurface(::GeoInterface.PolygonTrait, geom::customgeom)::"PointTrait"
-GeoInterface.boundary(::GeoInterface.PolygonTrait, geom::customgeom)::"LineStringTrait"
+GeoInterface.area(::PolygonTrait, geom::customgeom)::Real
+GeoInterface.centroid(::PolygonTrait, geom::customgeom)::"PointTrait"
+GeoInterface.pointonsurface(::PolygonTrait, geom::customgeom)::"PointTrait"
+GeoInterface.boundary(::PolygonTrait, geom::customgeom)::"LineStringTrait"
 ```
 
 A `geom::customgeom` with "GeometryCollection"-like traits has to implement the following methods:
 ```julia
-GeoInterface.geomtype(geom::customgeom) = GeoInterface.GeometryCollectionTrait()
-GeoInterface.ncoord(::GeoInterface.GeometryCollectionTrait, geom::customgeom)::Integer
-GeoInterface.ngeom(::GeoInterface.GeometryCollectionTrait, geom::customgeom)::Integer
-GeoInterface.getgeom(::GeoInterface.GeometryCollectionTrait,geom::customgeomm, i)::"GeometryTrait"
+GeoInterface.geomtype(geom::customgeom) = GeometryCollectionTrait()
+GeoInterface.ncoord(::GeometryCollectionTrait, geom::customgeom)::Integer
+GeoInterface.ngeom(::GeometryCollectionTrait, geom::customgeom)::Integer
+GeoInterface.getgeom(::GeometryCollectionTrait,geom::customgeomm, i)::"GeometryTrait"
 ```
 
 A `geom::customgeom` with "MultiPoint"-like traits has to implement the following methods:
 ```julia
-GeoInterface.geomtype(geom::customgeom) = GeoInterface.MultiPointTrait()
-GeoInterface.ncoord(::GeoInterface.MultiPointTrait, geom::customgeom)::Integer
+GeoInterface.geomtype(geom::customgeom) = MultiPointTrait()
+GeoInterface.ncoord(::MultiPointTrait, geom::customgeom)::Integer
 
 # These alias for npoint and getpoint
-GeoInterface.ngeom(::GeoInterface.MultiPointTrait, geom::customgeom)::Integer
-GeoInterface.getgeom(::GeoInterface.MultiPointTrait, geom::customgeom, i)::"PointTrait"
+GeoInterface.ngeom(::MultiPointTrait, geom::customgeom)::Integer
+GeoInterface.getgeom(::MultiPointTrait, geom::customgeom, i)::"PointTrait"
 ```
 
 A `geom::customgeom` with "MultiLineString"-like traits has to implement the following methods:
 ```julia
-GeoInterface.geomtype(geom::customgeom) = GeoInterface.MultiLineStringTrait()
-GeoInterface.ncoord(::GeoInterface.MultiLineStringTrait, geom::customgeom)::Integer
+GeoInterface.geomtype(geom::customgeom) = MultiLineStringTrait()
+GeoInterface.ncoord(::MultiLineStringTrait, geom::customgeom)::Integer
 
 # These alias for nlinestring and getlinestring
-GeoInterface.ngeom(::GeoInterface.MultiLineStringTrait, geom::customgeom)::Integer
-GeoInterface.getgeom(::GeoInterface.MultiLineStringTrait,geom::customgeomm, i)::"LineStringTrait"
+GeoInterface.ngeom(::MultiLineStringTrait, geom::customgeom)::Integer
+GeoInterface.getgeom(::MultiLineStringTrait,geom::customgeomm, i)::"LineStringTrait"
 ```
 
 A `geom::customgeom` with "MultiPolygon"-like traits has to implement the following methods:
 ```julia
-GeoInterface.geomtype(geom::customgeom) = GeoInterface.MultiPolygonTrait()
-GeoInterface.ncoord(::GeoInterface.MultiPolygonTrait, geom::customgeom)::Integer
+GeoInterface.geomtype(geom::customgeom) = MultiPolygonTrait()
+GeoInterface.ncoord(::MultiPolygonTrait, geom::customgeom)::Integer
 
 # These alias for npolygon and getpolygon
-GeoInterface.ngeom(::GeoInterface.MultiPolygonTrait, geom::customgeom)::Integer
-GeoInterface.getgeom(::GeoInterface.MultiPolygonTrait, geom::customgeom, i)::"PolygonTrait"
+GeoInterface.ngeom(::MultiPolygonTrait, geom::customgeom)::Integer
+GeoInterface.getgeom(::MultiPolygonTrait, geom::customgeom, i)::"PolygonTrait"
 ```

--- a/docs/src/tutorials/usage.md
+++ b/docs/src/tutorials/usage.md
@@ -41,10 +41,10 @@ julia> geom = createpolygon(...)::ArchGDAL.IGeometry  # no idea about the interf
 julia> isgeometry(geom)
 True
 julia> geomtype(geom)
-GeoInterface.PolygonTrait()
+PolygonTrait()
 julia> ext = exterior(geom);
 julia> geomtype(ext)
-GeoInterface.LineStringTrait()
+LineStringTrait()
 julia> getcoords.(getpoint.(Ref(ext), 1:npoint(ext)))
 [[1.,2.],[2.,3.],[1.,2.]]
 julia> coordinates(geom)  # fallback based on ngeom & npoint above

--- a/src/GeoInterface.jl
+++ b/src/GeoInterface.jl
@@ -4,6 +4,43 @@ using Base.Iterators: flatten
 
 export testgeometry, isgeometry, geomtype, ncoord, getcoord, ngeom, getgeom
 
+# traits
+export AbstractGeometryTrait,
+    AbstractGeometryCollectionTrait,
+    GeometryCollectionTrait,
+    AbstractPointTrait,
+    PointTrait,
+    AbstractCurveTrait,
+    AbstractLineStringTrait,
+    LineStringTrait,
+    LineTrait,
+    LinearRingTrait,
+    CircularStringTrait,
+    CompoundCurveTrait,
+    AbstractSurfaceTrait,
+    AbstractCurvePolygonTrait,
+    CurvePolygonTrait,
+    AbstractPolygonTrait,
+    PolygonTrait,
+    TriangleTrait,
+    RectangleTrait,
+    QuadTrait,
+    PentagonTrait,
+    HexagonTrait,
+    AbstractPolyHedralSurfaceTrait,
+    PolyHedralSurfaceTrait,
+    TINTrait,
+    AbstractMultiPointTrait,
+    MultiPointTrait,
+    AbstractMultiCurveTrait,
+    MultiCurveTrait,
+    AbstractMultiLineStringTrait,
+    MultiLineStringTrait,
+    AbstractMultiSurfaceTrait,
+    MultiSurfaceTrait,
+    AbstractMultiPolygonTrait,
+    MultiPolygonTrait
+
 include("types.jl")
 include("interface.jl")
 include("fallbacks.jl")

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -112,16 +112,16 @@ Gets the expected, possible abstract, (sub)trait for subgeometries (retrieved wi
 
 # Examples
 ```jldoctest; setup = :(using GeoInterface)
-julia> GeoInterface.subtrait(GeoInterface.LineStringTrait())
-GeoInterface.AbstractPointTrait
-julia> GeoInterface.subtrait(GeoInterface.PolygonTrait())  # Any of LineStringTrait, LineTrait, LinearRingTrait
-GeoInterface.AbstractLineStringTrait
+julia> GeoInterface.subtrait(LineStringTrait())
+AbstractPointTrait
+julia> GeoInterface.subtrait(PolygonTrait())  # Any of LineStringTrait, LineTrait, LinearRingTrait
+AbstractLineStringTrait
 ```
 ```jldoctest; setup = :(using GeoInterface)
 # `nothing` is returned when there's no subtrait or when it's not known beforehand
-julia> isnothing(GeoInterface.subtrait(GeoInterface.PointTrait()))
+julia> isnothing(GeoInterface.subtrait(PointTrait()))
 true
-julia> isnothing(GeoInterface.subtrait(GeoInterface.GeometryCollectionTrait()))
+julia> isnothing(GeoInterface.subtrait(GeometryCollectionTrait()))
 true
 ```
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -43,7 +43,7 @@ properties(feat) = nothing
 """
     GeoInterface.geomtype(geom) => T <: AbstractGeometry
 
-Returns the geometry type, such as [`GeoInterface.PolygonTrait`](@ref) or [`GeoInterface.PointTrait`](@ref).
+Returns the geometry type, such as [`PolygonTrait`](@ref) or [`PointTrait`](@ref).
 """
 geomtype(geom) = nothing
 

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -12,20 +12,20 @@ using Test
     struct MyCollection end
 
     GeoInterface.isgeometry(::MyPoint) = true
-    GeoInterface.geomtype(::MyPoint) = GeoInterface.PointTrait()
-    GeoInterface.ncoord(::GeoInterface.PointTrait, geom::MyPoint) = 2
-    GeoInterface.getcoord(::GeoInterface.PointTrait, geom::MyPoint, i) = [1, 2][i]
+    GeoInterface.geomtype(::MyPoint) = PointTrait()
+    GeoInterface.ncoord(::PointTrait, geom::MyPoint) = 2
+    GeoInterface.getcoord(::PointTrait, geom::MyPoint, i) = [1, 2][i]
 
     GeoInterface.isgeometry(::MyCurve) = true
-    GeoInterface.geomtype(::MyCurve) = GeoInterface.LineStringTrait()
-    GeoInterface.ngeom(::GeoInterface.LineStringTrait, geom::MyCurve) = 2
-    GeoInterface.getgeom(::GeoInterface.LineStringTrait, geom::MyCurve, i) = MyPoint()
-    Base.convert(::Type{MyCurve}, ::GeoInterface.LineStringTrait, geom) = geom
+    GeoInterface.geomtype(::MyCurve) = LineStringTrait()
+    GeoInterface.ngeom(::LineStringTrait, geom::MyCurve) = 2
+    GeoInterface.getgeom(::LineStringTrait, geom::MyCurve, i) = MyPoint()
+    Base.convert(::Type{MyCurve}, ::LineStringTrait, geom) = geom
 
     GeoInterface.isgeometry(::MyPolygon) = true
-    GeoInterface.geomtype(::MyPolygon) = GeoInterface.PolygonTrait()
-    GeoInterface.ngeom(::GeoInterface.PolygonTrait, geom::MyPolygon) = 2
-    GeoInterface.getgeom(::GeoInterface.PolygonTrait, geom::MyPolygon, i) = MyCurve()
+    GeoInterface.geomtype(::MyPolygon) = PolygonTrait()
+    GeoInterface.ngeom(::PolygonTrait, geom::MyPolygon) = 2
+    GeoInterface.getgeom(::PolygonTrait, geom::MyPolygon, i) = MyCurve()
 
 
     @testset "Point" begin
@@ -65,7 +65,7 @@ using Test
 end
 
 @testset "Defaults" begin
-    @test GeoInterface.subtrait(GeoInterface.TINTrait()) == GeoInterface.TriangleTrait
+    @test GeoInterface.subtrait(TINTrait()) == TriangleTrait
 end
 
 @testset "Feature" begin
@@ -73,9 +73,9 @@ end
     struct Point end
 
     GeoInterface.isgeometry(::Point) = true
-    GeoInterface.geomtype(::Point) = GeoInterface.PointTrait()
-    GeoInterface.ncoord(::GeoInterface.PointTrait, geom::Point) = 2
-    GeoInterface.getcoord(::GeoInterface.PointTrait, geom::Point, i) = [1, 2][i]
+    GeoInterface.geomtype(::Point) = PointTrait()
+    GeoInterface.ncoord(::PointTrait, geom::Point) = 2
+    GeoInterface.getcoord(::PointTrait, geom::Point, i) = [1, 2][i]
 
     GeoInterface.isfeature(::Row) = true
     GeoInterface.geometry(r::Row) = Point()


### PR DESCRIPTION
This is onto the branch of #49, but separate because it might warrant some discussion.

One of the advantages of adding *Trait to all trait types, is that they wont clash with other packages. The disadvantage is that some of them get even longer, e.g. `GeoInterface.AbstractGeometryCollectionTrait`. But we can alleviate this by exporting all the traits. What do you think?

For my own reference, replacements made with

```
GeoInterface.(\w+)Trait
$1Trait
```