### PR TITLE
Features fixes

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -39,10 +39,10 @@ GeoInterface.properties(nt::NamedTuple) = _is_namedtuple_feature(nt) ? _nt_prope
 
 # Use Val to force constant propagation through `reduce`
 function _nt_properties(nt::NamedTuple{K}) where K
-    valkeys = reduce(K; init=()) do acc, k
+    keys = reduce(K; init=()) do acc, k
         k == :geometry ? acc : (acc..., k)
     end
-    return NamedTuple{valkeys}(nt)
+    return NamedTuple{keys}(nt)
 end
 
 const MaybeArrayFeatureCollection = AbstractArray{<:NamedTuple}

--- a/src/base.jl
+++ b/src/base.jl
@@ -42,7 +42,7 @@ function _nt_properties(nt::NamedTuple{K}) where K
     valkeys = reduce(K; init=()) do acc, k
         k == :geometry ? acc : (acc..., k)
     end
-    return nt[valkeys]
+    return NamedTuple{valkeys}(nt)
 end
 
 const MaybeArrayFeatureCollection = AbstractArray{<:NamedTuple}

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -92,7 +92,6 @@ Returns the object type, such as [`FeatureTrait`](@ref).
 For all `isgeometry` objects `trait` is the same as `geomtrait(obj)`,
 e.g. [`PointTrait`](@ref).
 """
-# trait(geom::T) where T = isgeometry(T) ? geomtrait(geom) : nothing
 trait(geom) = geomtrait(geom)
 
 # All types

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,5 +1,7 @@
+"An AbstractTrait type for all geometries, features and feature collections."
+abstract type AbstractTrait end
 "An AbstractGeometryTrait type for all geometries."
-abstract type AbstractGeometryTrait end
+abstract type AbstractGeometryTrait <: AbstractTrait end
 
 "An AbstractGeometryCollectionTrait type for all geometrycollections."
 abstract type AbstractGeometryCollectionTrait <: AbstractGeometryTrait end
@@ -82,11 +84,11 @@ struct MultiPolygonTrait <: AbstractMultiPolygonTrait end
 
 
 "An AbstractFeatureTrait for all features"
-abstract type AbstractFeatureTrait end
+abstract type AbstractFeatureTrait <: AbstractTrait end
 "A FeatureTrait holds `geometries`, `properties` and an `extent`"
 struct FeatureTrait <: AbstractFeatureTrait end
 
 "An AbstractFeatureCollectionTrait for all feature collections"
-abstract type AbstractFeatureCollectionTrait end
+abstract type AbstractFeatureCollectionTrait <: AbstractTrait end
 "A FeatureCollectionTrait holds objects of `FeatureTrait` and an `extent`"
 struct FeatureCollectionTrait <: AbstractFeatureCollectionTrait end

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -344,7 +344,9 @@ end
     end
 
     @testset "NamedTupleFeature" begin
-        feature = (; geometry=(1, 2), properties=(a="x", b="y"))
+        feature = (; geometry=(1, 2), a="x", b="y", c="z")
+        GeoInterface.geometry(feature) = (1, 2)
+        @test GeoInterface.properties(feature) == (a="x", b="y", c="z")
         @test GeoInterface.testfeature(feature)
         @test GeoInterface.testfeaturecollection([feature, feature])
     end


### PR DESCRIPTION
This changes a few things from the last PR #61 

Features are now defined for any `NamedTuple` that has a `geometry` field, and all other fields are `properties`.

An `AbstractTrait` type is also added to unify all the traits.

Some of these methods like `geometry` and `nfeature` are returning `nothing` where they could instead throw a `MethodError` like another object without the method defined. I'm not sure which is best here.