### PR TITLE
stop using Base.convert

### DIFF
--- a/docs/src/guides/developer.md
+++ b/docs/src/guides/developer.md
@@ -42,11 +42,14 @@ And lastly, there are many other optional functions for each specific geometry. 
 ### Conversion
 It is useful if others can convert any custom geometry into your
 geometry type, if their custom geometry supports GeoInterface as well.
-This requires the following method, where the implementation should be defined in terms
+This requires the following methods, where the implementation should be defined in terms
 of GeoInterface methods like `ngeom`, `getgeom`, or just `coordinates` calls.
 
 ```julia
-GeoInterface.convert(::Type{T}, ::LineStringTrait, geom) = ...  # slow custom conversion based on ngeom and getgeom
+# This method will get called on GeoInterface.convert(::Type{T}, geom)
+# if geomtrait(geom) == LineStringTrait()
+GeoInterface.convert(::Type{CustomLineString}, ::LineStringTrait, geom) = ...
+GeoInterface.convert(::Type{CustomPolygon}, ::PolygonTrait, geom) = ...
 ```
 
 ## Required for Feature(Collection)s

--- a/docs/src/guides/developer.md
+++ b/docs/src/guides/developer.md
@@ -42,12 +42,11 @@ And lastly, there are many other optional functions for each specific geometry. 
 ### Conversion
 It is useful if others can convert any custom geometry into your
 geometry type, if their custom geometry supports GeoInterface as well.
-This requires the following three methods, and the last one requires more code to generate `T` with `ngeom`, `getgeom` or just `coordinates` calls.
+This requires the following method, where the implementation should be defined in terms
+of GeoInterface methods like `ngeom`, `getgeom`, or just `coordinates` calls.
 
 ```julia
-Base.convert(::Type{T}, geom) where T<:AbstractPackageType = Base.convert(T, geomtrait(geom), geom)
-Base.convert(::Type{T}, ::LineStringTrait, geom::T) = geom  # fast fallthrough without conversion
-Base.convert(::Type{T}, ::LineStringTrait, geom) = ...  # slow custom conversion based on ngeom and getgeom
+GeoInterface.convert(::Type{T}, ::LineStringTrait, geom) = ...  # slow custom conversion based on ngeom and getgeom
 ```
 
 ## Required for Feature(Collection)s

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -109,7 +109,8 @@ function coordinates(t::AbstractFeatureTrait, feature)
 end
 coordinates(t::AbstractFeatureCollectionTrait, fc) = [coordinates(f) for f in getfeature(fc)]
 
-Base.convert(T::Type, ::AbstractGeometryTrait, geom) = error("Conversion is enabled for type $T, but not implemented. Please report this issue to the package maintainer.")
+# no conversion needed
+convert(::Type{T}, ::AbstractTrait, x::T) where {T} = x
 
 # Subtraits
 

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -103,14 +103,11 @@ getfeature(t::AbstractFeatureCollectionTrait, fc) = (getfeature(t, fc, i) for i 
 # Backwards compatibility
 coordinates(t::AbstractPointTrait, geom) = collect(getcoord(t, geom))
 coordinates(t::AbstractGeometryTrait, geom) = collect(coordinates.(getgeom(t, geom)))
-function coordinates(t::AbstractFeatureTrait, feature) 
+function coordinates(t::AbstractFeatureTrait, feature)
     geom = geometry(feature)
     isnothing(geom) ? [] : coordinates(geom)
 end
 coordinates(t::AbstractFeatureCollectionTrait, fc) = [coordinates(f) for f in getfeature(fc)]
-
-# no conversion needed
-convert(::Type{T}, ::AbstractTrait, x::T) where {T} = x
 
 # Subtraits
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -606,10 +606,10 @@ coordinates(obj) = coordinates(trait(obj), obj)
 """
     convert(type::CustomGeom, geom)
 
-Convert `geom` into the `CustomGeom` type if both geom as the CustomGeom package
-have implemented GeoInterface.
+Create a `CustomGeom` from any `geom` that implements the GeoInterface.
 """
 convert(T, geom) = convert(T, geomtrait(geom), geom)
+convert(::Type{T}, x::T) where {T} = x  # no-op
 
 """
     astext(geom) -> WKT

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -35,8 +35,6 @@ using Test
     GeoInterface.geomtrait(::MyCurve) = LineStringTrait()
     GeoInterface.ngeom(::LineStringTrait, geom::MyCurve) = 2
     GeoInterface.getgeom(::LineStringTrait, geom::MyCurve, i) = MyPoint()
-    Base.convert(T::Type{MyCurve}, geom::X) where {X} = Base.convert(T, geomtrait(geom), geom)
-    Base.convert(::Type{MyCurve}, ::LineStringTrait, geom::MyCurve) = geom
 
     GeoInterface.isgeometry(::MyPolygon) = true
     GeoInterface.geomtrait(::MyPolygon) = PolygonTrait()
@@ -235,15 +233,9 @@ end
     struct XCurve end
     struct XPolygon end
 
-    Base.convert(T::Type{XCurve}, geom::X) where {X} = Base.convert(T, geomtrait(geom), geom)
-    Base.convert(::Type{XCurve}, ::LineStringTrait, geom::XCurve) = geom  # fast fallthrough
-    Base.convert(::Type{XCurve}, ::LineStringTrait, geom) = geom
-
     geom = MyCurve()
-    @test !isnothing(convert(MyCurve, geom))
-
-    Base.convert(T::Type{XPolygon}, geom::X) where {X} = Base.convert(T, geomtrait(geom), geom)
-    @test_throws Exception convert(MyPolygon, geom)
+    @test GeoInterface.convert(MyCurve, geom) === geom
+    @test_throws Exception GeoInterface.convert(MyPolygon, geom)
 end
 
 @testset "Operations" begin


### PR DESCRIPTION
Following discussion in #49.

I tried implementing Base.convert as suggested by the [GeoInterface docs](https://juliageo.org/GeoInterface.jl/stable/guides/developer/#Conversion) for GeometryBasics, testing with GeoJSON geometries.

The first method is needed to send the 2-arg convert through the 3-arg method with the trait argument.
```julia
function Base.convert(::Type{T}, geom) where {T<:AbstractGeometry}
    return convert(T, GeoInterface.geomtrait(geom), geom)
end
```

This method is `geom::Any`, so if there are any convert methods with more specific types already defined, I cannot hit this anymore. This was the case with trying to `convert(GeometryBasics.Point, p::GeoJSON.Point)`. `GeoJSON.Point` is an `AbstractVector`, and there is a method defined for those already. However that method doesn't work (since the number of dimensions, 2 or 3, is not statically known).

So here I removed all `Base.convert` usages from docs and examples. There is already a `GeoInterface.convert` method

```julia
convert(T, geom) = convert(T, geomtrait(geom), geom)
```

That works well, and I figured we don't need to ask developers to add a fast passthrough if we can define it ourselves in fallback.jl:

```julia
# no conversion needed
convert(::Type{T}, ::AbstractTrait, x::T) where {T} = x
```
