### PR TITLE
Added fallback method for `extent`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "GeoInterface"
 uuid = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 authors = ["JuliaGeo and contributors"]
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 Extents = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
 
 [compat]
-Extents = "0.1"
+Extents = "0.1.1"
 julia = "1"
 
 [extras]

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -103,11 +103,23 @@ getfeature(t::AbstractFeatureCollectionTrait, fc) = (getfeature(t, fc, i) for i 
 # Backwards compatibility
 coordinates(t::AbstractPointTrait, geom) = collect(getcoord(t, geom))
 coordinates(t::AbstractGeometryTrait, geom) = collect(coordinates.(getgeom(t, geom)))
-function coordinates(t::AbstractFeatureTrait, feature) 
+function coordinates(t::AbstractFeatureTrait, feature)
     geom = geometry(feature)
     isnothing(geom) ? [] : coordinates(geom)
 end
 coordinates(t::AbstractFeatureCollectionTrait, fc) = [coordinates(f) for f in getfeature(fc)]
+
+function extent(t::AbstractPointTrait, geom)
+    coords = collect(getcoord(geom))
+    names = coordnames(geom)
+    return Extent(NamedTuple{names}(zip(coords, coords)))
+end
+extent(t::AbstractGeometryTrait, geom) = reduce(Extents.union, extent.(getgeom(t, geom)))
+function extent(t::AbstractFeatureTrait, feature)
+    geom = geometry(feature)
+    isnothing(geom) ? [] : extent(geom)
+end
+extent(t::AbstractFeatureCollectionTrait, fc) = reduce(Extents.union, (extent(f) for f in getfeature(fc)))
 
 Base.convert(T::Type, ::AbstractGeometryTrait, geom) = error("Conversion is enabled for type $T, but not implemented. Please report this issue to the package maintainer.")
 

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -108,17 +108,18 @@ function coordinates(::AbstractFeatureTrait, feature)
 end
 coordinates(t::AbstractFeatureCollectionTrait, fc) = [coordinates(f) for f in getfeature(t, fc)]
 
-function extent(t::AbstractPointTrait, geom)
+extent(::AbstractTrait, _) = nothing
+function calc_extent(t::AbstractPointTrait, geom)
     coords = collect(getcoord(t, geom))
     names = coordnames(geom)
     return Extent(NamedTuple{names}(zip(coords, coords)))
 end
-extent(t::AbstractGeometryTrait, geom) = reduce(Extents.union, (extent(f) for f in getgeom(t, geom)))
-function extent(::AbstractFeatureTrait, feature)
+calc_extent(t::AbstractGeometryTrait, geom) = reduce(Extents.union, (extent(f) for f in getgeom(t, geom)))
+function calc_extent(::AbstractFeatureTrait, feature)
     geom = geometry(feature)
     isnothing(geom) ? nothing : extent(geom)
 end
-extent(t::AbstractFeatureCollectionTrait, fc) = reduce(Extents.union, filter(!isnothing, collect(extent(f) for f in getfeature(t, fc))))
+calc_extent(t::AbstractFeatureCollectionTrait, fc) = reduce(Extents.union, filter(!isnothing, collect(extent(f) for f in getfeature(t, fc))))
 
 Base.convert(T::Type, ::AbstractGeometryTrait, geom) = error("Conversion is enabled for type $T, but not implemented. Please report this issue to the package maintainer.")
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -411,13 +411,12 @@ In SF this is defined as `SRID`.
 crs(geom) = crs(geomtrait(geom), geom)
 
 """
-    extent(geom) -> T <: Extents.Extent
+    extent(obj) -> T <: Extents.Extent
 
-Retrieve the extent (bounding box) for given geom.
+Retrieve the extent (bounding box) for given geom or feature.
 In SF this is defined as `envelope`.
 """
-extent(geom) = extent(geomtrait(geom), geom)
-extent(trait, geom) = nothing
+extent(obj) = extent(trait(obj), obj)
 
 """
     bbox(geom) -> T <: Extents.Extent

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -411,12 +411,19 @@ In SF this is defined as `SRID`.
 crs(geom) = crs(geomtrait(geom), geom)
 
 """
-    extent(obj) -> T <: Extents.Extent
+    extent(obj, fallback=true) -> T <: Extents.Extent
 
 Retrieve the extent (bounding box) for given geom or feature.
 In SF this is defined as `envelope`.
+
+When `fallback` is true, and the obj does not have an extent,
+it is calculated from the coordinates of all geometries in `obj`.
 """
-extent(obj) = extent(trait(obj), obj)
+function extent(obj; fallback=true)
+    ex = extent(trait(obj), obj)
+    isnothing(ex) && fallback && return calc_extent(trait(obj), obj)
+    return nothing
+end
 
 """
     bbox(geom) -> T <: Extents.Extent

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -86,7 +86,6 @@ using Test
     GeoInterface.trait(feature::MyFeature) = FeatureTrait()
     GeoInterface.geometry(f::MyFeature) = f.geometry
     GeoInterface.properties(f::MyFeature) = f.properties
-    GeoInterface.extent(f::MyFeature) = nothing
 
     GeoInterface.isfeaturecollection(fc::Type{<:MyFeatureCollection}) = true
     GeoInterface.trait(fc::MyFeatureCollection) = FeatureCollectionTrait()
@@ -233,13 +232,15 @@ end
 @testset "Feature" begin
     feature = MyFeature((1, 2), (a=10, b=20))
     @test GeoInterface.testfeature(feature)
+    @test GeoInterface.extent(feature) == Extents.Extent(X=(1, 1), Y=(2, 2))
 end
 
 @testset "FeatureCollection" begin
     features = MyFeatureCollection(
-        [MyFeature(MyPoint(), (a="1", b="2")), MyFeature(MyPolygon(), (a="3", b="4"))]
+        [MyFeature(MyPoint(), (a="1", b="2")), MyFeature(MyPolygon(), (a="3", b="4")), MyFeature(nothing, (a="5", b="6"))]
     )
     @test GeoInterface.testfeaturecollection(features)
+    @test GeoInterface.extent(FeatureCollectionTrait(), features) == Extents.Extent(X=(1, 1), Y=(2, 2))
 end
 
 @testset "Conversion" begin

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -110,6 +110,7 @@ using Test
         @test !GeoInterface.ismeasured(geom)
         @test GeoInterface.extent(geom) == Extents.Extent(X=(1, 1), Y=(2, 2))
         @test GeoInterface.bbox(geom) == Extents.Extent(X=(1, 1), Y=(2, 2))
+        @test isnothing(GeoInterface.extent(geom, fallback=false))
 
         geom = MyEmptyPoint()
         @test GeoInterface.coordnames(geom) == ()
@@ -240,7 +241,7 @@ end
         [MyFeature(MyPoint(), (a="1", b="2")), MyFeature(MyPolygon(), (a="3", b="4")), MyFeature(nothing, (a="5", b="6"))]
     )
     @test GeoInterface.testfeaturecollection(features)
-    @test GeoInterface.extent(FeatureCollectionTrait(), features) == Extents.Extent(X=(1, 1), Y=(2, 2))
+    @test GeoInterface.extent(features) == Extents.Extent(X=(1, 1), Y=(2, 2))
 end
 
 @testset "Conversion" begin

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -1,4 +1,5 @@
 using GeoInterface
+using Extents
 using Test
 
 @testset "Developer" begin
@@ -33,6 +34,7 @@ using Test
 
     GeoInterface.isgeometry(::MyCurve) = true
     GeoInterface.geomtrait(::MyCurve) = LineStringTrait()
+    GeoInterface.ncoord(::LineStringTrait, geom::MyCurve) = 2
     GeoInterface.ngeom(::LineStringTrait, geom::MyCurve) = 2
     GeoInterface.getgeom(::LineStringTrait, geom::MyCurve, i) = MyPoint()
     Base.convert(T::Type{MyCurve}, geom::X) where {X} = Base.convert(T, geomtrait(geom), geom)
@@ -40,36 +42,43 @@ using Test
 
     GeoInterface.isgeometry(::MyPolygon) = true
     GeoInterface.geomtrait(::MyPolygon) = PolygonTrait()
+    GeoInterface.ncoord(::PolygonTrait, geom::MyPolygon) = 2
     GeoInterface.ngeom(::PolygonTrait, geom::MyPolygon) = 2
     GeoInterface.getgeom(::PolygonTrait, geom::MyPolygon, i) = MyCurve()
 
     GeoInterface.isgeometry(::MyTriangle) = true
     GeoInterface.geomtrait(::MyTriangle) = TriangleTrait()
+    GeoInterface.ncoord(::TriangleTrait, geom::MyTriangle) = 2
     GeoInterface.ngeom(::TriangleTrait, geom::MyTriangle) = 3
     GeoInterface.getgeom(::TriangleTrait, geom::MyTriangle, i) = MyCurve()
 
     GeoInterface.isgeometry(::MyMultiPoint) = true
     GeoInterface.geomtrait(::MyMultiPoint) = MultiPointTrait()
+    GeoInterface.ncoord(::MultiPointTrait, geom::MyMultiPoint) = 2
     GeoInterface.ngeom(::MultiPointTrait, geom::MyMultiPoint) = 2
     GeoInterface.getgeom(::MultiPointTrait, geom::MyMultiPoint, i) = MyPoint()
 
     GeoInterface.isgeometry(::MyMultiCurve) = true
     GeoInterface.geomtrait(::MyMultiCurve) = MultiCurveTrait()
+    GeoInterface.ncoord(::MultiCurveTrait, geom::MyMultiCurve) = 2
     GeoInterface.ngeom(::MultiCurveTrait, geom::MyMultiCurve) = 2
     GeoInterface.getgeom(::MultiCurveTrait, geom::MyMultiCurve, i) = MyCurve()
 
     GeoInterface.isgeometry(::MyMultiPolygon) = true
     GeoInterface.geomtrait(::MyMultiPolygon) = MultiPolygonTrait()
+    GeoInterface.ncoord(::MultiPolygonTrait, geom::MyMultiPolygon) = 2
     GeoInterface.ngeom(::MultiPolygonTrait, geom::MyMultiPolygon) = 2
     GeoInterface.getgeom(::MultiPolygonTrait, geom::MyMultiPolygon, i) = MyPolygon()
 
     GeoInterface.isgeometry(::MyTIN) = true
     GeoInterface.geomtrait(::MyTIN) = PolyhedralSurfaceTrait()
+    GeoInterface.ncoord(::PolyhedralSurfaceTrait, geom::MyTIN) = 2
     GeoInterface.ngeom(::PolyhedralSurfaceTrait, geom::MyTIN) = 2
     GeoInterface.getgeom(::PolyhedralSurfaceTrait, geom::MyTIN, i) = MyTriangle()
 
     GeoInterface.isgeometry(::MyCollection) = true
     GeoInterface.geomtrait(::MyCollection) = GeometryCollectionTrait()
+    GeoInterface.ncoord(::GeometryCollectionTrait, geom::MyCollection) = 2
     GeoInterface.ngeom(::GeometryCollectionTrait, geom::MyCollection) = 2
     GeoInterface.getgeom(::GeometryCollectionTrait, geom::MyCollection, i) = MyCurve()
 
@@ -94,19 +103,20 @@ using Test
         @test_throws ArgumentError GeoInterface.m(geom)
         @test ncoord(geom) === 2
         @test collect(getcoord(geom)) == [1, 2]
+        @test GeoInterface.coordinates(geom) == [1, 2]
         @test getcoord(geom, 1) === 1
         @test GeoInterface.coordnames(geom) == (:X, :Y)
         @test !GeoInterface.isempty(geom)
         @test !GeoInterface.is3d(geom)
         @test !GeoInterface.ismeasured(geom)
+        @test GeoInterface.extent(geom) == Extents.Extent(X=(1, 1), Y=(2, 2))
+        @test GeoInterface.bbox(geom) == Extents.Extent(X=(1, 1), Y=(2, 2))
 
         geom = MyEmptyPoint()
         @test GeoInterface.coordnames(geom) == ()
         @test GeoInterface.isempty(geom)
 
         @test isnothing(GeoInterface.crs(geom))
-        @test isnothing(GeoInterface.extent(geom))
-        @test isnothing(GeoInterface.bbox(geom))
     end
 
     @testset "LineString" begin
@@ -186,6 +196,7 @@ using Test
         polygons = GeoInterface.getpolygon(geom)
         polygon = GeoInterface.getpolygon(geom, 1)
         @test GeoInterface.coordinates(geom) == [[[[1, 2], [1, 2]], [[1, 2], [1, 2]]], [[[1, 2], [1, 2]], [[1, 2], [1, 2]]]]
+        @test GeoInterface.extent(geom) == Extents.Extent(X=(1, 1), Y=(2, 2))
         @test collect(polygons) == [MyPolygon(), MyPolygon()]
     end
 


### PR DESCRIPTION
While slow, it's very useful for packages that don't implement it itself, as we use `extent` in packages such as https://github.com/evetion/GeoAcceleratedArrays.jl/pull/3