### PR TITLE
run jet and fix bugs

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -85,7 +85,12 @@ npoint(::HexagonTrait, geom) = 6
 nring(::HexagonTrait, geom) = 1
 
 # TODO Only simple if it's also not intersecting itself, except for its endpoints
-issimple(t::AbstractCurveTrait, geom) = allunique((getpoint(t, geom, i) for i in 1:npoint(geom)-1)) && allunique((getpoint(t, geom, i) for i in 2:npoint(t, geom)))
+function issimple(t::AbstractCurveTrait, geom)
+    n = npoint(t, geom)
+    n > 1 || return true
+    allunique((getpoint(t, geom, i) for i in 1:n-1)) && 
+    allunique((getpoint(t, geom, i) for i in 2:n))
+end
 isclosed(t::AbstractCurveTrait, geom) = getpoint(t, geom, 1) == getpoint(t, geom, npoint(t, geom))
 isring(t::AbstractCurveTrait, geom) = issimple(t, geom) && isclosed(t, geom)
 
@@ -102,7 +107,10 @@ getfeature(t::AbstractFeatureCollectionTrait, fc) = (getfeature(t, fc, i) for i 
 
 # Backwards compatibility
 coordinates(t::AbstractPointTrait, geom) = collect(getcoord(t, geom))
-coordinates(t::AbstractGeometryTrait, geom) = collect(coordinates.(getgeom(t, geom)))
+function coordinates(t::AbstractGeometryTrait, geom)
+    ngeom(t, geom) > 0 || return []
+    collect(coordinates.(getgeom(t, geom)))
+end
 function coordinates(t::AbstractFeatureTrait, feature) 
     geom = geometry(feature)
     isnothing(geom) ? [] : coordinates(geom)


### PR DESCRIPTION
JET found a bunch of places we were not checking for zero/one length geoms. After fixing it still complains about some as it doesn't seem to see the runtime check on `npoint` means the iterator will never return `nothing`.

```julia
# Run from the GeoInteface environment
julia> JET.report_package(GeoInterface)
...
═════ 3 possible errors found ═════
┌ @ /home/raf/.julia/dev/GeoInterface/src/interface.jl:125 GeoInterface.issimple(geomtrait(geom), geom)
│┌ @ /home/raf/.julia/dev/GeoInterface/src/fallbacks.jl:90 GeoInterface.allunique(Base.Generator(#23, 1 GeoInterface.:(:) GeoInterface.npoint(t, geom) GeoInterface.:- 1))
││┌ @ set.jl:408 Base.indexed_iterate(x, 1)
│││┌ @ tuple.jl:91 x = iterate(I)
││││ no matching method found `iterate(::Nothing)`: x = iterate(I::Nothing)::Union{}
│││└───────────────
││┌ @ set.jl:408 Base.indexed_iterate(x, 2, _6)
│││┌ @ tuple.jl:96 x = iterate(I, state)
││││ no matching method found `iterate(::Nothing, ::Int64)`: x = iterate(I::Nothing, state::Int64)::Union{}
│││└───────────────
┌ @ /home/raf/.julia/dev/GeoInterface/src/fallbacks.jl:122 GeoInterface.error(string("Conversion is enabled for type ", T, ", but not implemented. Please report this issue t
o the package maintainer."))
│┌ @ error.jl:35 error(::String)
││ may throw: Base.throw(Base.ErrorException(s::String)::ErrorException)::Union{}
│└───────────────

```