### PR TITLE
fix dispatch on base types and test them

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -1,29 +1,36 @@
 # Implementation of GeoInterface for Base Types
 
+
+const PointTuple2 = Tuple{<:Real,<:Real}
+const PointTuple3 = Tuple{<:Real,<:Real,<:Real}
+const PointTuple4 = Tuple{<:Real,<:Real,<:Real,<:Real}
+const PointTuple = Union{PointTuple2,PointTuple3,PointTuple4}
+
 GeoInterface.isgeometry(::Type{<:AbstractVector{<:Real}}) = true
 GeoInterface.geomtrait(::AbstractVector{<:Real}) = PointTrait()
 GeoInterface.ncoord(::PointTrait, geom::AbstractVector{<:Real}) = Base.length(geom)
 GeoInterface.getcoord(::PointTrait, geom::AbstractVector{<:Real}, i) = getindex(geom, i)
 
-GeoInterface.isgeometry(::Type{<:NTuple{N,<:Real}}) where {N} = true
-GeoInterface.geomtrait(::NTuple{N,<:Real}) where {N} = PointTrait()
-GeoInterface.ncoord(::PointTrait, geom::NTuple{N,<:Real}) where {N} = N
-GeoInterface.getcoord(::PointTrait, geom::NTuple{N,<:Real}, i) where {N} = getindex(geom, i)
+GeoInterface.isgeometry(::Type{<:PointTuple}) = true
+GeoInterface.geomtrait(::PointTuple) = PointTrait()
+GeoInterface.ncoord(::PointTrait, geom::PointTuple) = Base.length(geom)
+GeoInterface.getcoord(::PointTrait, geom::PointTuple, i) = getindex(geom, i)
 
-for i in 2:4
-    sig = NamedTuple{default_coord_names[1:i],NTuple{i,T}} where {T<:Real}
-    GeoInterface.isgeometry(::Type{<:sig}) = true
-    GeoInterface.geomtrait(::sig) = PointTrait()
-    GeoInterface.ncoord(::PointTrait, geom::sig) = i
-    GeoInterface.getcoord(::PointTrait, geom::sig, i) = getindex(geom, i)
+for (i, pointtype) in enumerate((PointTuple2, PointTuple3, PointTuple4))
+    keys = default_coord_names[1:i+1]
+    sig = NamedTuple{keys,<:pointtype}
+    @eval GeoInterface.isgeometry(::Type{<:$sig}) = true
+    @eval GeoInterface.geomtrait(::$sig) = PointTrait()
+    @eval GeoInterface.ncoord(::PointTrait, geom::$sig) = $i + 1
+    @eval GeoInterface.getcoord(::PointTrait, geom::$sig, i) = getindex(geom, i)
 end
 
 # Custom coordinate order/names NamedTuple
-GeoInterface.isgeometry(::Type{<:NamedTuple{Keys,NTuple{N,T}}}) where {Keys,N,T<:Real} = all(in(default_coord_names), Keys)
-GeoInterface.geomtrait(::NamedTuple{Keys,NTuple{N,T}}) where {Keys,N,T<:Real} = PointTrait()
-GeoInterface.ncoord(::PointTrait, geom::NamedTuple{Keys,NTuple{N,T}}) where {Keys,N,T<:Real} = Base.length(geom)
-GeoInterface.getcoord(::PointTrait, geom::NamedTuple{Keys,NTuple{N,T}}, i) where {Keys,N,T<:Real} = getindex(geom, i)
-GeoInterface.coordnames(::PointTrait, geom::NamedTuple{Keys,NTuple{N,T}}) where {Keys,N,T<:Real} = Keys
+GeoInterface.isgeometry(::Type{<:NamedTuple{Keys,<:PointTuple}}) where {Keys} = all(in(default_coord_names), Keys)
+GeoInterface.geomtrait(::NamedTuple{Keys,<:PointTuple}) where {Keys} = PointTrait()
+GeoInterface.ncoord(::PointTrait, geom::NamedTuple{Keys,<:PointTuple}) where {Keys} = Base.length(geom)
+GeoInterface.getcoord(::PointTrait, geom::NamedTuple{Keys,<:PointTuple}, i) where {Keys} = getindex(geom, i)
+GeoInterface.coordnames(::PointTrait, geom::NamedTuple{Keys,<:PointTuple}) where {Keys} = Keys
 
 
 # Default features using NamedTuple and AbstractArray
@@ -33,7 +40,7 @@ _is_namedtuple_feature(::Type{<:NamedTuple{K}}) where K = :geometry in K
 _is_namedtuple_feature(nt::NamedTuple) = _is_namedtuple_feature(typeof(nt))
 
 GeoInterface.isfeature(T::Type{<:NamedTuple}) = _is_namedtuple_feature(T)
-GeoInterface.trait(nt::NamedTuple) = _is_namedtuple_feature(nt) ? FeatureTrait() : nothing
+GeoInterface.trait(nt::NamedTuple) = _is_namedtuple_feature(nt) ? FeatureTrait() : geomtrait(nt)
 GeoInterface.geometry(nt::NamedTuple) = _is_namedtuple_feature(nt) ? nt.geometry : nothing
 GeoInterface.properties(nt::NamedTuple) = _is_namedtuple_feature(nt) ? _nt_properties(nt) : nothing
 
@@ -51,7 +58,7 @@ _is_array_featurecollection(::Type{<:AbstractArray{T}}) where {T<:NamedTuple} = 
 _is_array_featurecollection(A::AbstractArray{<:NamedTuple}) = _is_array_featurecollection(typeof(A))
 
 GeoInterface.isfeaturecollection(T::Type{<:MaybeArrayFeatureCollection}) = _is_array_featurecollection(T)
-GeoInterface.trait(fc::MaybeArrayFeatureCollection) = _is_array_featurecollection(fc) ? FeatureCollectionTrait() : nothing
+GeoInterface.trait(fc::MaybeArrayFeatureCollection) = _is_array_featurecollection(fc) ? FeatureCollectionTrait() : geomtrait(fc)
 GeoInterface.nfeature(::FeatureCollectionTrait, fc::MaybeArrayFeatureCollection) = _is_array_featurecollection(fc) ? Base.length(fc) : nothing
 GeoInterface.getfeature(::FeatureCollectionTrait, fc::MaybeArrayFeatureCollection, i::Integer) = _is_array_featurecollection(fc) ? fc[i] : nothing
 GeoInterface.geometrycolumns(fc::MaybeArrayFeatureCollection) = _is_array_featurecollection(fc) ? (:geometry,) : nothing

--- a/src/base.jl
+++ b/src/base.jl
@@ -74,10 +74,10 @@ GeoInterface.geomtrait(::NamedTuplePoint) = PointTrait()
 GeoInterface.ncoord(::PointTrait, geom::NamedTuplePoint) = Base.length(geom)
 GeoInterface.getcoord(::PointTrait, geom::NamedTuplePoint, i) = getindex(geom, i)
 GeoInterface.coordnames(::PointTrait, geom::NamedTuplePoint) = _keys(typeof(geom))
-GeoInterface.x(::PointTrait, geom::NamedTuplePoint, i) = geom.X
-GeoInterface.y(::PointTrait, geom::NamedTuplePoint, i) = geom.Y
-GeoInterface.z(::PointTrait, geom::NamedTuplePoint, i) = geom.Z
-GeoInterface.m(::PointTrait, geom::NamedTuplePoint, i) = geom.M
+GeoInterface.x(::PointTrait, geom::NamedTuplePoint) = geom.X
+GeoInterface.y(::PointTrait, geom::NamedTuplePoint) = geom.Y
+GeoInterface.z(::PointTrait, geom::NamedTuplePoint) = geom.Z
+GeoInterface.m(::PointTrait, geom::NamedTuplePoint) = geom.M
 
 
 # Default features using NamedTuple and AbstractArray

--- a/src/base.jl
+++ b/src/base.jl
@@ -25,13 +25,59 @@ for (i, pointtype) in enumerate((PointTuple2, PointTuple3, PointTuple4))
     @eval GeoInterface.getcoord(::PointTrait, geom::$sig, i) = getindex(geom, i)
 end
 
-# Custom coordinate order/names NamedTuple
-GeoInterface.isgeometry(::Type{<:NamedTuple{Keys,<:PointTuple}}) where {Keys} = all(in(default_coord_names), Keys)
-GeoInterface.geomtrait(::NamedTuple{Keys,<:PointTuple}) where {Keys} = PointTrait()
-GeoInterface.ncoord(::PointTrait, geom::NamedTuple{Keys,<:PointTuple}) where {Keys} = Base.length(geom)
-GeoInterface.getcoord(::PointTrait, geom::NamedTuple{Keys,<:PointTuple}, i) where {Keys} = getindex(geom, i)
-GeoInterface.coordnames(::PointTrait, geom::NamedTuple{Keys,<:PointTuple}) where {Keys} = Keys
 
+const NamedTuplePoints = Union{
+    NamedTuple{(:X, :Y),<:PointTuple2},
+    NamedTuple{(:Y, :X),<:PointTuple2},
+    NamedTuple{(:X, :Y, :Z),<:PointTuple3},
+    NamedTuple{(:X, :Z, :Y),<:PointTuple3},
+    NamedTuple{(:Z, :Y, :X),<:PointTuple3},
+    NamedTuple{(:Z, :X, :Y),<:PointTuple3},
+    NamedTuple{(:Y, :X, :Z),<:PointTuple3},
+    NamedTuple{(:Y, :Z, :X),<:PointTuple3},
+    NamedTuple{(:X, :Y, :M),<:PointTuple3},
+    NamedTuple{(:X, :M, :Y),<:PointTuple3},
+    NamedTuple{(:M, :Y, :X),<:PointTuple3},
+    NamedTuple{(:M, :X, :Y),<:PointTuple3},
+    NamedTuple{(:Y, :X, :Z),<:PointTuple3},
+    NamedTuple{(:Y, :Z, :X),<:PointTuple3},
+    NamedTuple{(:X, :Y, :Z, :M),<:PointTuple4},
+    NamedTuple{(:X, :Y, :M, :Z),<:PointTuple4},
+    NamedTuple{(:X, :Z, :Y, :M),<:PointTuple4},
+    NamedTuple{(:X, :Z, :M, :Y),<:PointTuple4},
+    NamedTuple{(:X, :M, :Z, :Y),<:PointTuple4},
+    NamedTuple{(:X, :M, :Y, :Z),<:PointTuple4},
+    NamedTuple{(:Y, :X, :Z, :M),<:PointTuple4},
+    NamedTuple{(:Y, :X, :M, :Z),<:PointTuple4},
+    NamedTuple{(:Y, :Z, :X, :M),<:PointTuple4},
+    NamedTuple{(:Y, :Z, :M, :X),<:PointTuple4},
+    NamedTuple{(:Y, :M, :Z, :X),<:PointTuple4},
+    NamedTuple{(:Y, :M, :X, :Z),<:PointTuple4},
+    NamedTuple{(:Z, :Y, :X, :M),<:PointTuple4},
+    NamedTuple{(:Z, :Y, :M, :X),<:PointTuple4},
+    NamedTuple{(:Z, :X, :Y, :M),<:PointTuple4},
+    NamedTuple{(:Z, :X, :M, :Y),<:PointTuple4},
+    NamedTuple{(:Z, :M, :X, :Y),<:PointTuple4},
+    NamedTuple{(:Z, :M, :Y, :X),<:PointTuple4},
+    NamedTuple{(:M, :Y, :Z, :X),<:PointTuple4},
+    NamedTuple{(:M, :Y, :X, :Z),<:PointTuple4},
+    NamedTuple{(:M, :Z, :Y, :X),<:PointTuple4},
+    NamedTuple{(:M, :Z, :X, :Y),<:PointTuple4},
+    NamedTuple{(:M, :X, :Z, :Y),<:PointTuple4},
+    NamedTuple{(:M, :X, :Y, :Z),<:PointTuple4},
+}
+
+_keys(::Type{<:NamedTuple{K}}) where K = K
+# Custom coordinate order/names NamedTuple
+GeoInterface.isgeometry(::Type{T}) where {T<:NamedTuplePoints} = all(in(default_coord_names), _keys(T))
+GeoInterface.geomtrait(::NamedTuplePoints) where {Keys} = PointTrait()
+GeoInterface.ncoord(::PointTrait, geom::NamedTuplePoints) where {Keys} = Base.length(geom)
+GeoInterface.getcoord(::PointTrait, geom::NamedTuplePoints, i) where {Keys} = getindex(geom, i)
+GeoInterface.coordnames(::PointTrait, geom::NamedTuplePoints) = _keys(typeof(geom))
+GeoInterface.x(::PointTrait, geom::NamedTuplePoints, i) where {Keys} = geom.X
+GeoInterface.y(::PointTrait, geom::NamedTuplePoints, i) where {Keys} = geom.Y
+GeoInterface.z(::PointTrait, geom::NamedTuplePoints, i) where {Keys} = geom.Z
+GeoInterface.m(::PointTrait, geom::NamedTuplePoints, i) where {Keys} = geom.M
 
 # Default features using NamedTuple and AbstractArray
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -26,7 +26,8 @@ for (i, pointtype) in enumerate((PointTuple2, PointTuple3, PointTuple4))
 end
 
 
-const NamedTuplePoints = Union{
+# Define all possible NamedTuple points
+const NamedTuplePoint = Union{
     NamedTuple{(:X, :Y),<:PointTuple2},
     NamedTuple{(:Y, :X),<:PointTuple2},
     NamedTuple{(:X, :Y, :Z),<:PointTuple3},
@@ -68,16 +69,16 @@ const NamedTuplePoints = Union{
 }
 
 _keys(::Type{<:NamedTuple{K}}) where K = K
-# Custom coordinate order/names NamedTuple
-GeoInterface.isgeometry(::Type{T}) where {T<:NamedTuplePoints} = all(in(default_coord_names), _keys(T))
-GeoInterface.geomtrait(::NamedTuplePoints) where {Keys} = PointTrait()
-GeoInterface.ncoord(::PointTrait, geom::NamedTuplePoints) where {Keys} = Base.length(geom)
-GeoInterface.getcoord(::PointTrait, geom::NamedTuplePoints, i) where {Keys} = getindex(geom, i)
-GeoInterface.coordnames(::PointTrait, geom::NamedTuplePoints) = _keys(typeof(geom))
-GeoInterface.x(::PointTrait, geom::NamedTuplePoints, i) where {Keys} = geom.X
-GeoInterface.y(::PointTrait, geom::NamedTuplePoints, i) where {Keys} = geom.Y
-GeoInterface.z(::PointTrait, geom::NamedTuplePoints, i) where {Keys} = geom.Z
-GeoInterface.m(::PointTrait, geom::NamedTuplePoints, i) where {Keys} = geom.M
+GeoInterface.isgeometry(::Type{T}) where {T<:NamedTuplePoint} = all(in(default_coord_names), _keys(T))
+GeoInterface.geomtrait(::NamedTuplePoint) = PointTrait()
+GeoInterface.ncoord(::PointTrait, geom::NamedTuplePoint) = Base.length(geom)
+GeoInterface.getcoord(::PointTrait, geom::NamedTuplePoint, i) = getindex(geom, i)
+GeoInterface.coordnames(::PointTrait, geom::NamedTuplePoint) = _keys(typeof(geom))
+GeoInterface.x(::PointTrait, geom::NamedTuplePoint, i) = geom.X
+GeoInterface.y(::PointTrait, geom::NamedTuplePoint, i) = geom.Y
+GeoInterface.z(::PointTrait, geom::NamedTuplePoint, i) = geom.Z
+GeoInterface.m(::PointTrait, geom::NamedTuplePoint, i) = geom.M
+
 
 # Default features using NamedTuple and AbstractArray
 

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -316,7 +316,9 @@ end
     end
 
     @testset "Tuple" begin
-        geom = (1, 2)
+        geom = (1, 2.0f0)
+        @test GeoInterface.trait(geom) isa PointTrait
+        @test GeoInterface.geomtrait(geom) isa PointTrait
         @test testgeometry(geom)
         @test GeoInterface.x(geom) == 1
         @test GeoInterface.ncoord(geom) == 2
@@ -324,14 +326,16 @@ end
     end
 
     @testset "NamedTuple" begin
-        geom = (; X=1, Y=2)
+        geom = (; X=1, Y=2.0)
+        @test GeoInterface.trait(geom) isa PointTrait
+        @test GeoInterface.geomtrait(geom) isa PointTrait
         @test testgeometry(geom)
         @test GeoInterface.x(geom) == 1
         @test collect(GeoInterface.getcoord(geom)) == [1, 2]
 
-        geom = (; X=1, Y=2, Z=3)
+        geom = (; X=1.0, Y=2.0, Z=0x03)
         @test testgeometry(geom)
-        geom = (; X=1, Y=2, Z=3, M=4)
+        geom = (; X=1, Y=2, Z=3.0f0, M=4.0)
         @test testgeometry(geom)
         geom = (; Z=3, X=1, Y=2, M=4)
         @test testgeometry(geom)

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -321,30 +321,50 @@ end
         @test GeoInterface.geomtrait(geom) isa PointTrait
         @test testgeometry(geom)
         @test GeoInterface.x(geom) == 1
+        @test GeoInterface.y(geom) == 2.0f0
         @test GeoInterface.ncoord(geom) == 2
         @test collect(GeoInterface.getcoord(geom)) == [1, 2]
     end
 
     @testset "NamedTuple" begin
         geom = (; X=1, Y=2.0)
+        @test GeoInterface.is3d(geom) == false
+        @test GeoInterface.ismeasured(geom) == false
         @test GeoInterface.trait(geom) isa PointTrait
         @test GeoInterface.geomtrait(geom) isa PointTrait
         @test testgeometry(geom)
         @test GeoInterface.x(geom) == 1
+        @test GeoInterface.y(geom) == 1
         @test collect(GeoInterface.getcoord(geom)) == [1, 2]
+
+        geom = (; X=1, Y=2, Z=3.0f0, M=4.0)
+        @test GeoInterface.trait(geom) isa PointTrait
+        @test GeoInterface.geomtrait(geom) isa PointTrait
+        @test GeoInterface.is3d(geom)
+        @test GeoInterface.ismeasured(geom)
+        @test GeoInterface.coordnames(geom) == (:X, :Y, :Z, :M)
+        @test GeoInterface.ncoord(geom) == 4
+        @test testgeometry(geom)
+        @test GeoInterface.x(geom) === 1
+        @test GeoInterface.y(geom) === 2
+        @test GeoInterface.z(geom) === 3.0f0
+        @test GeoInterface.m(geom) === 4.0
+        @test GeoInterface.ncoord(geom) == 4
+        @test GeoInterface.getcoord(geom, 1) === 1
+        @test GeoInterface.getcoord(geom, 2) === 2
+        @test GeoInterface.getcoord(geom, 3) === 3.0f0
+        @test GeoInterface.getcoord(geom, 4) === 4.0
+        @test collect(GeoInterface.getcoord(geom)) == [1, 2, 3, 4]
 
         geom = (; X=1.0, Y=2.0, Z=0x03)
         @test testgeometry(geom)
-        geom = (; X=1, Y=2, Z=3.0f0, M=4.0)
-        @test testgeometry(geom)
+        @test GeoInterface.is3d(geom)
+        @test GeoInterface.ismeasured(geom) == false
+        @test GeoInterface.coordnames(geom) == (:X, :Y, :Z)
         geom = (; Z=3, X=1, Y=2, M=4)
         @test testgeometry(geom)
-
-        @test GeoInterface.x(geom) == 1
-        @test GeoInterface.m(geom) == 4
-        @test GeoInterface.ncoord(geom) == 4
         @test collect(GeoInterface.getcoord(geom)) == [3, 1, 2, 4]
-
+        @test GeoInterface.coordnames(geom) == (:Z, :X, :Y, :M)
     end
 
     @testset "NamedTupleFeature" begin

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -334,7 +334,7 @@ end
         @test GeoInterface.geomtrait(geom) isa PointTrait
         @test testgeometry(geom)
         @test GeoInterface.x(geom) == 1
-        @test GeoInterface.y(geom) == 1
+        @test GeoInterface.y(geom) == 2.0
         @test collect(GeoInterface.getcoord(geom)) == [1, 2]
 
         geom = (; X=1, Y=2, Z=3.0f0, M=4.0)


### PR DESCRIPTION
This fixes `Tuple` and `NamedTuple` points for mixed integers and where `trait` was only looking at `NamedTuple` as a `FeatureTrait` rather than also as a `PointTrait`

See https://github.com/JuliaGeo/Leaflet.jl/issues/6