### PR TITLE
use isdefined to check module has geointerface_geomtype function

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -115,6 +115,7 @@ coordinates(t::AbstractFeatureCollectionTrait, fc) = [coordinates(f) for f in ge
 # corresponding geometry type
 function convert(package::Module, geom)
     t = trait(geom)
+    isdefined(package, :geointerface_geomtype) || throw(ArgumentError("$package does not implement `geointerface_geomtype`. Please request this be implemented in a github issue."))
     convert(package.geointerface_geomtype(t), t, geom)
 end
 

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -384,3 +384,4 @@ module ConvertTestModule
 end
 
 @test GeoInterface.convert(ConvertTestModule, MyPolygon()) == ConvertTestModule.TestPolygon()
+@test_throws GeoInterface.convert(ConvertTestModule, MyPolygon()) == ConvertTestModule.TestPolygon()

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -383,5 +383,8 @@ module ConvertTestModule
     GeoInterface.convert(::Type{<:TestPolygon}, ::PolygonTrait, geom) = TestPolygon()
 end
 
+module BadModule
+end
+
 @test GeoInterface.convert(ConvertTestModule, MyPolygon()) == ConvertTestModule.TestPolygon()
-@test_throws GeoInterface.convert(ConvertTestModule, MyPolygon()) == ConvertTestModule.TestPolygon()
+@test_throws ArgumentError GeoInterface.convert(BadModule, MyPolygon()) == ConvertTestModule.TestPolygon()


### PR DESCRIPTION
Somehow this didn't make it in before