### PR TITLE
fallback for crs with no geotrait

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -94,7 +94,7 @@ issimple(t::AbstractMultiPointTrait, geom) = allunique((getgeom(t, geom)))
 issimple(t::AbstractMultiCurveTrait, geom) = all(issimple.(getgeom(t, geom)))
 isclosed(t::AbstractMultiCurveTrait, geom) = all(isclosed.(getgeom(t, geom)))
 
-crs(::AbstractGeometryTrait, geom) = nothing
+crs(::Union{AbstractGeometryTrait, Nothing}, geom) = nothing
 
 # FeatureCollection
 getfeature(t::AbstractFeatureCollectionTrait, fc) = (getfeature(t, fc, i) for i in 1:nfeature(t, fc))

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -109,6 +109,7 @@ GeoInterface.getfeature(::FeatureCollectionTrait, fc::MyFeatureCollection, i::In
         @test GeoInterface.isempty(geom)
 
         @test isnothing(GeoInterface.crs(geom))
+        @test isnothing(GeoInterface.crs([]))
     end
 
     @testset "LineString" begin


### PR DESCRIPTION
For `x` such that `geomtrait(x) === nothing`, `crs(x)` results in an error.  This PR provides a fallback that returns `nothing` instead.