### PR TITLE
add LinearRing recipes and test plotting, also test LineString

### DIFF
--- a/GeoInterfaceRecipes/src/GeoInterfaceRecipes.jl
+++ b/GeoInterfaceRecipes/src/GeoInterfaceRecipes.jl
@@ -44,7 +44,7 @@ RecipesBase.@recipe function f(t::Union{GI.AbstractLineStringTrait,GI.MultiLineS
     _coordvecs(t, geom)
 end
 
-RecipesBase.@recipe function f(t::Union{GI.PolygonTrait,GI.MultiPolygonTrait}, geom)
+RecipesBase.@recipe function f(t::Union{GI.PolygonTrait,GI.MultiPolygonTrait,GI.LinearRingTrait}, geom)
     seriestype --> :shape
     _coordvecs(t, geom)
 end
@@ -97,6 +97,14 @@ function _coordvecs(::GI.MultiLineStringTrait, geom)
     else
         vecs = ntuple(_ -> Array{Float64}(undef, n), 2)
         return loop!(vecs, geom)
+    end
+end
+function _coordvecs(::GI.LinearRingTrait, geom)
+    points = GI.getpoint(geom)
+    if GI.is3d(geom)
+        return getcoord.(points, 1), getcoord.(points, 2), getcoord.(points, 3)
+    else
+        return getcoord.(points, 1), getcoord.(points, 2)
     end
 end
 function _coordvecs(::GI.PolygonTrait, geom)

--- a/GeoInterfaceRecipes/test/runtests.jl
+++ b/GeoInterfaceRecipes/test/runtests.jl
@@ -9,6 +9,7 @@ abstract type MyAbstractGeom{N} end
 struct MyPoint{N} <: MyAbstractGeom{N} end
 struct MyCurve{N} <: MyAbstractGeom{N} end
 struct MyLinearRing{N} <: MyAbstractGeom{N} end
+struct MyLineString{N} <: MyAbstractGeom{N} end
 struct MyPolygon{N} <: MyAbstractGeom{N} end
 struct MyMultiPoint{N} <: MyAbstractGeom{N} end
 struct MyMultiCurve{N} <: MyAbstractGeom{N} end
@@ -41,6 +42,11 @@ GeoInterface.ngeom(::GeoInterface.LinearRingTrait, geom::MyLinearRing) = 3
 GeoInterface.getgeom(::GeoInterface.LinearRingTrait, geom::MyLinearRing{N}, i) where {N} = MyPoint{N}()
 GeoInterface.convert(::Type{MyLinearRing}, ::GeoInterface.LinearRingTrait, geom) = geom
 
+GeoInterface.geomtrait(::MyLineString) = GeoInterface.LineStringTrait()
+GeoInterface.ngeom(::GeoInterface.LineStringTrait, geom::MyLineString) = 3
+GeoInterface.getgeom(::GeoInterface.LineStringTrait, geom::MyLineString{N}, i) where {N} = MyPoint{N}()
+GeoInterface.convert(::Type{MyLineString}, ::GeoInterface.LineStringTrait, geom) = geom
+
 GeoInterface.geomtrait(::MyPolygon) = GeoInterface.PolygonTrait()
 GeoInterface.ngeom(::GeoInterface.PolygonTrait, geom::MyPolygon) = 2
 GeoInterface.getgeom(::GeoInterface.PolygonTrait, geom::MyPolygon{N}, i) where {N} = MyCurve{N}()
@@ -71,6 +77,7 @@ GeoInterface.nfeature(::GeoInterface.FeatureTrait, geom::MyFeature) = 1
     plot(MyPoint{2}())
     plot(MyCurve{2}())
     plot(MyLinearRing{2}())
+    plot(MyLineString{2}())
     plot(MyMultiPoint{2}())
     plot(MyPolygon{2}())
     plot(MyMultiPolygon{2}())
@@ -79,6 +86,7 @@ GeoInterface.nfeature(::GeoInterface.FeatureTrait, geom::MyFeature) = 1
     plot(MyPoint{3}())
     plot(MyCurve{3}())
     plot(MyLinearRing{3}())
+    plot(MyLineString{3}())
     plot(MyMultiPoint{3}())
     plot(MyPolygon{3}())
     plot(MyMultiPolygon{3}())


### PR DESCRIPTION
Found linear ring had no recipe while working on https://github.com/JuliaGeo/Shapefile.jl/pull/85

I'm not sure how this worked before for `LinearRing`, it already had tests but were failing on 1.9 for me.

I also tested `LineString` while fixing this.