### PR TITLE
fall back to Extents.extent

### DIFF
--- a/docs/src/guides/developer.md
+++ b/docs/src/guides/developer.md
@@ -37,6 +37,10 @@ GeoInterface.crs(geomtrait(geom), geom::customgeom)::GeoFormatTypes.GeoFormat
 GeoInterface.extent(geomtrait(geom), geom::customgeom)::Extents.Extent
 ```
 
+For extents, `Extents.extent(geom::customgeom)` is the fallback method for GeoInterface.extent, 
+and can be used instead here for wider interoperability. If neither is defined,
+`GeoInterface.extent` will calculate the extent from the points of the geometry.
+
 And lastly, there are many other optional functions for each specific geometry. GeoInterface provides fallback implementations based on the generic functions above, but these are not optimized. These are detailed in [Fallbacks](@ref).
 
 ### Conversion

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -108,7 +108,7 @@ function coordinates(t::AbstractFeatureTrait, feature)
 end
 coordinates(t::AbstractFeatureCollectionTrait, fc) = [coordinates(f) for f in getfeature(t, fc)]
 
-extent(::AbstractTrait, _) = nothing
+extent(::AbstractTrait, x) = Extents.extent(x)
 function calc_extent(t::AbstractPointTrait, geom)
     coords = collect(getcoord(t, geom))
     names = coordnames(geom)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -416,8 +416,11 @@ crs(geom) = crs(geomtrait(geom), geom)
 Retrieve the extent (bounding box) for given geom or feature.
 In SF this is defined as `envelope`.
 
+`Extents.extent(obj)` will be called if `extent(trait(obj), obj)`,
+is not defined so it may be preferable to define `Extents.extent` directly.
+
 When `fallback` is true, and the obj does not have an extent,
-it is calculated from the coordinates of all geometries in `obj`.
+an extent is calculated from the coordinates of all geometries in `obj`.
 """
 function extent(obj; fallback=true)
     ex = extent(trait(obj), obj)

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -486,6 +486,6 @@ struct ExtentPolygon end
 GeoInterface.geomtrait(::ExtentPolygon) = PolygonTrait()
 Extents.extent(::ExtentPolygon) = Extent(X=(1, 2), Y=(3, 4))
 
-@testset "Extents.jl extent fallback"
+@testset "Extents.jl extent fallback" begin
     @test GeoInterface.extent(ExtentPolygon()) == Extent(X=(1, 2), Y=(3, 4))
 end

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -480,3 +480,12 @@ end
 
 @test GeoInterface.convert(ConvertTestModule, MyPolygon()) == ConvertTestModule.TestPolygon()
 @test_throws ArgumentError GeoInterface.convert(BadModule, MyPolygon()) == ConvertTestModule.TestPolygon()
+
+
+struct ExtentPolygon end
+GeoInterface.geomtrait(::ExtentPolygon) = PolygonTrait()
+Extents.extent(::ExtentPolygon) = Extent(X=(1, 2), Y=(3, 4))
+
+@testset "Extents.jl extent fallback"
+    @test GeoInterface.extent(ExtentPolygon()) == Extent(X=(1, 2), Y=(3, 4))
+end


### PR DESCRIPTION
@evetion what do you think of falling back to `Extents.extent` ?

It would solve e.g. this issue https://github.com/rafaqz/Extents.jl/issues/7

Also means packages can define `Extents.extent` instead of `GeoInterface.extent`. So the difference would be that `GeoInterface.extent` calculates the extent if it doesn't exist because it knows how to do that with geometries.

That may have solved my earlier issue with always doing the calculations, wish I thought about this more then...