### PR TITLE
Use map instead of collect with a broadcast.

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -101,7 +101,7 @@ getfeature(t::AbstractFeatureCollectionTrait, fc) = (getfeature(t, fc, i) for i 
 
 # Backwards compatibility
 coordinates(t::AbstractPointTrait, geom) = collect(getcoord(t, geom))
-coordinates(t::AbstractGeometryTrait, geom) = collect(coordinates.(getgeom(t, geom)))
+coordinates(t::AbstractGeometryTrait, geom) = map(coordinates, getgeom(t, geom))
 function coordinates(t::AbstractFeatureTrait, feature)
     geom = geometry(feature)
     isnothing(geom) ? [] : coordinates(geom)


### PR DESCRIPTION
Over at https://github.com/JuliaGeo/LibGEOS.jl/issues/160, this makes `@code_warntype` green for `coordinates(polygon)` and changes the type for coordinates on a MultiPolygon from Any to a Vector.