### PR TITLE
Tweak extent fallback

### DIFF
--- a/src/GeoInterface.jl
+++ b/src/GeoInterface.jl
@@ -1,7 +1,6 @@
 module GeoInterface
 
-import Extents
-using Extents: Extent
+using Extents: Extents, Extent
 using Base.Iterators: flatten
 
 export testgeometry, isgeometry, trait, geomtrait, ncoord, getcoord, ngeom, getgeom

--- a/src/GeoInterface.jl
+++ b/src/GeoInterface.jl
@@ -1,6 +1,7 @@
 module GeoInterface
 
-using Extents
+import Extents
+using Extents: Extent
 using Base.Iterators: flatten
 
 export testgeometry, isgeometry, trait, geomtrait, ncoord, getcoord, ngeom, getgeom

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -107,9 +107,9 @@ function coordinates(t::AbstractFeatureTrait, feature)
     geom = geometry(feature)
     isnothing(geom) ? [] : coordinates(geom)
 end
-coordinates(t::AbstractFeatureCollectionTrait, fc) = [coordinates(f) for f in getfeature(t, fc)]
+coordinates(t::AbstractFeatureCollectionTrait, fc) = map(f -> coordinates(f), getfeature(t, fc))
 
-extent(::AbstractTrait, x) = Extents.extent(x)
+extent(::Any, x) = Extents.extent(x)
 function calc_extent(t::AbstractPointTrait, geom)
     coords = collect(getcoord(t, geom))
     names = coordnames(geom)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -423,9 +423,10 @@ When `fallback` is true, and the obj does not have an extent,
 an extent is calculated from the coordinates of all geometries in `obj`.
 """
 function extent(obj; fallback=true)
-    isnothing(trait(obj)) && return Extents.extent(obj)
-    ex = extent(trait(obj), obj)
-    isnothing(ex) && fallback && return calc_extent(trait(obj), obj)
+    t = trait(obj)
+    isnothing(t) && return Extents.extent(obj)
+    ex = extent(t, obj)
+    isnothing(ex) && fallback && return calc_extent(t, obj)
     return ex
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -423,6 +423,7 @@ When `fallback` is true, and the obj does not have an extent,
 an extent is calculated from the coordinates of all geometries in `obj`.
 """
 function extent(obj; fallback=true)
+    isnothing(trait(obj)) && return Extents.extent(obj)
     ex = extent(trait(obj), obj)
     isnothing(ex) && fallback && return calc_extent(trait(obj), obj)
     return ex

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -489,6 +489,6 @@ Extents.extent(::ExtentPolygon) = Extent(X=(1, 2), Y=(3, 4))
 
 @testset "Extents.jl extent fallback" begin
     @test GeoInterface.extent(ExtentPolygon()) == Extent(X=(1, 2), Y=(3, 4))
-    @test GeoInterface.extent(1) == nothing
-    @test GeoInterface.extent(nothing, 1) == nothing
+    @test isnothing(GeoInterface.extent(1))
+    @test isnothing(GeoInterface.extent(nothing, 1))
 end

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -489,4 +489,6 @@ Extents.extent(::ExtentPolygon) = Extent(X=(1, 2), Y=(3, 4))
 
 @testset "Extents.jl extent fallback" begin
     @test GeoInterface.extent(ExtentPolygon()) == Extent(X=(1, 2), Y=(3, 4))
+    @test GeoInterface.extent(1) == nothing
+    @test GeoInterface.extent(nothing, 1) == nothing
 end


### PR DESCRIPTION
This PR lets non-geometries pass through to Extents.jl if used in `GeoInterface.extent`. Just a convenience really so the function here just works in more cases.

I also used `import` rather than `using` at the same time for correctness.