### PR TITLE
allow LineStringTrait in Polygon wrapper

### DIFF
--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -98,7 +98,7 @@ for (geomtype, trait, childtype, child_trait, length_check, nesting) in (
         (:LineString, :LineStringTrait, :Point, :PointTrait, >=(2), 1),
         (:LinearRing, :LinearRingTrait, :Point, :PointTrait, >=(3), 1),
         (:MultiPoint, :MultiPointTrait, :Point, :PointTrait, nothing, 1),
-        (:Polygon, :PolygonTrait, :LinearRing, :LinearRingTrait, nothing, 2),
+        (:Polygon, :PolygonTrait, :LinearRing, :AbstractCurveTrait, nothing, 2),
         (:MultiLineString, :MultiLineStringTrait, :LineString, :LineStringTrait, nothing, 2),
         (:MultiCurve, :MultiCurveTrait, :LineString, :AbstractCurveTrait, nothing, 2),
         (:MultiPolygon, :MultiPolygonTrait, :Polygon, :PolygonTrait, nothing, 3),

--- a/test/test_wrappers.jl
+++ b/test/test_wrappers.jl
@@ -142,6 +142,10 @@ polygon = GI.Polygon([linearring, linearring])
 polygon_crs = GI.Polygon(polygon; crs=EPSG(4326))
 @test parent(polygon_crs) === parent(polygon)
 @test GI.crs(polygon_crs) === EPSG(4326)
+# Make sure `linestring` is also ok in polygons
+polygon = GI.Polygon([linestring, linestring])
+@test GI.getgeom(polygon, 1) === linestring
+@test collect(GI.getgeom(polygon)) == [linestring, linestring]
 
 # MultiPoint
 multipoint = GI.MultiPoint([(1, 2), (3, 4), (3, 2), (1, 4), (7, 8), (9, 10)])


### PR DESCRIPTION
Some packages don't have `LinearRing` types and builld `Polygon` from `LineString`, so that should be allowed here.