### PR TITLE
Add WellKnownGeometry as a package extension.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,14 +6,22 @@ version = "1.3.1"
 [deps]
 Extents = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
 
+[weakdeps]
+WellKnownGeometry = "0f680547-7be7-4555-8820-bb198eeb646b"
+
+[extensions]
+WellKnownGeometryExt = "WellKnownGeometry"
+
 [compat]
 Extents = "0.1.1"
+WellKnownGeometry = "0.2"
 julia = "1"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 GeoFormatTypes = "68eda718-8dee-11e9-39e7-89f7f65f511f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+WellKnownGeometry = "0f680547-7be7-4555-8820-bb198eeb646b"
 
 [targets]
-test = ["Test", "Documenter", "GeoFormatTypes"]
+test = ["Test", "Documenter", "GeoFormatTypes", "WellKnownGeometry"]

--- a/ext/WellKnownGeometryExt.jl
+++ b/ext/WellKnownGeometryExt.jl
@@ -1,0 +1,9 @@
+module WellKnownGeometryExt
+
+using GeoInterface
+using WellKnownGeometry
+
+GeoInterface.astext(::AbstractGeometryTrait, geom) = WellKnownGeometry.getwkt(geom)
+GeoInterface.asbinary(::AbstractGeometryTrait, geom) = WellKnownGeometry.getwkb(geom)
+
+end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -639,13 +639,13 @@ convert(::Type{T}, x::T) where {T} = x  # no-op
 """
     astext(geom) -> WKT
 
-Convert `geom` into Well Known Text (WKT) representation, such as `POINT (30 10)`.
+Convert `geom` into Well Known Text (WKT) representation, such as `POINT (30 10)`, wrapped in a `GeoFormatTypes.WellKnownText`.
 """
 astext(geom) = astext(geomtrait(geom), geom)
 
 """
     asbinary(geom) -> WKB
 
-Convert `geom` into Well Known Binary (WKB) representation, such as `000000000140000000000000004010000000000000`.
+Convert `geom` into Well Known Binary (WKB) representation, such as `000000000140000000000000004010000000000000`, wrapped in a `GeoFormatTypes.WellKnownBinary`.
 """
 asbinary(geom) = asbinary(geomtrait(geom), geom)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,4 +4,5 @@ using Test
 
 include("test_primitives.jl")
 include("test_wrappers.jl")
+include("test_extension.jl")
 doctest(GeoInterface)

--- a/test/test_extension.jl
+++ b/test/test_extension.jl
@@ -1,0 +1,10 @@
+using GeoInterface
+
+@testset "WellKnownGeometry extension (1.9+ only)" begin
+    if isdefined(Base, :get_extension)
+        using WellKnownGeometry
+        p = GeoInterface.Wrappers.Point(1.0, 2.0)
+        @test GeoInterface.astext(p).val == "POINT (1.0 2.0)"
+        @test GeoInterface.asbinary(p).val == [0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40]
+    end
+end


### PR DESCRIPTION
So there's a fallback for `asbinary` and `astext` once WellKnownGeometry is loaded.