### PR TITLE
Standardise `@enable` and apply it to `WrapperGeometry`

### DIFF
--- a/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
+++ b/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
@@ -94,7 +94,7 @@ end
 
 """
 
-    @enable(Geom)
+    GeoInterfaceRecipes.@enable(Geom)
 
 Enable Makie based plotting for a type `Geom` that implements the geometry interface 
 defined in `GeoInterface`.
@@ -107,12 +107,16 @@ end
 # overload GeoInterface for MyGeometry
 ...
 
-@enable MyGeometry
+# Enable Makie.jl plotting
+GeoInterfaceMakie.@enable MyGeometry
 ```
 """
 macro enable(Geom)
     esc(expr_enable(Geom))
 end
+
+# Enable Makie.jl for GeoInterface wrappers
+@enable GeoInterface.Wrappers.WrapperGeometry
 
 # TODO 
 # Features and Feature collections

--- a/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
+++ b/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
@@ -94,7 +94,7 @@ end
 
 """
 
-    GeoInterfaceRecipes.@enable(Geom)
+    GeoInterfaceMakie.@enable(GeometryType)
 
 Enable Makie based plotting for a type `Geom` that implements the geometry interface 
 defined in `GeoInterface`.

--- a/GeoInterfaceRecipes/src/GeoInterfaceRecipes.jl
+++ b/GeoInterfaceRecipes/src/GeoInterfaceRecipes.jl
@@ -6,34 +6,6 @@ const GI = GeoInterface
 
 export @enable_geo_plots
 
-"""
-     GeoInterfaceRecipes.@enable_geo_plots(typ)
-
-Macro to add plot recipes to a geometry type.
-"""
-macro enable_geo_plots(typ)
-    quote
-        # We recreate the apply_recipe functions manually here
-        # as nesting the @recipe macro doesn't work.
-        function RecipesBase.apply_recipe(plotattributes::Base.AbstractDict{Base.Symbol, Base.Any}, geom::$(esc(typ)))
-              @nospecialize
-              series_list = RecipesBase.RecipeData[]
-              RecipesBase.is_explicit(plotattributes, :label) || (plotattributes[:label] = :none)
-              Base.push!(series_list, RecipesBase.RecipeData(plotattributes, (GeoInterface.trait(geom), geom)))
-              return series_list
-        end
-        function RecipesBase.apply_recipe(plotattributes::Base.AbstractDict{Base.Symbol, Base.Any}, geom::Base.AbstractVector{<:Base.Union{Base.Missing,<:($(esc(typ)))}})
-              @nospecialize
-              series_list = RecipesBase.RecipeData[]
-              RecipesBase.is_explicit(plotattributes, :label) || (plotattributes[:label] = :none)
-              for g in Base.skipmissing(geom)
-                  Base.push!(series_list, RecipesBase.RecipeData(plotattributes, (GeoInterface.trait(g), g)))
-              end
-              return series_list
-        end
-    end
-end
-
 RecipesBase.@recipe function f(t::Union{GI.PointTrait,GI.MultiPointTrait}, geom)
     seriestype --> :scatter
     _coordvecs(t, geom)
@@ -157,5 +129,58 @@ function _geom2coordvecs!(xs, ys, zs, geom)
     end
     return xs, ys, zs
 end
+
+function expr_enable(typ)
+    quote
+        # We recreate the apply_recipe functions manually here
+        # as nesting the @recipe macro doesn't work.
+        function RecipesBase.apply_recipe(plotattributes::Base.AbstractDict{Base.Symbol, Base.Any}, geom::$(esc(typ)))
+              @nospecialize
+              series_list = RecipesBase.RecipeData[]
+              RecipesBase.is_explicit(plotattributes, :label) || (plotattributes[:label] = :none)
+              Base.push!(series_list, RecipesBase.RecipeData(plotattributes, (GeoInterface.trait(geom), geom)))
+              return series_list
+        end
+        function RecipesBase.apply_recipe(plotattributes::Base.AbstractDict{Base.Symbol, Base.Any}, geom::Base.AbstractVector{<:Base.Union{Base.Missing,<:($(esc(typ)))}})
+              @nospecialize
+              series_list = RecipesBase.RecipeData[]
+              RecipesBase.is_explicit(plotattributes, :label) || (plotattributes[:label] = :none)
+              for g in Base.skipmissing(geom)
+                  Base.push!(series_list, RecipesBase.RecipeData(plotattributes, (GeoInterface.trait(g), g)))
+              end
+              return series_list
+        end
+    end
+end
+
+"""
+     GeoInterfaceRecipes.@enable(typ)
+
+Macro to add plot recipes to a geometry type.
+
+# Usage
+
+```julia
+struct MyGeometry 
+...
+end
+# overload GeoInterface for MyGeometry
+...
+
+# Enable Plots.jl plotting
+GeoInterfaceRecipes.@enable_geo_plots MyGeometry
+```
+"""
+macro enable(typ)
+    expr_enable(typ)
+end
+
+# Compat
+macro enable_geo_plots(typ)
+    expr_enable(typ)
+end
+
+# Enable Plots.jl for GeoInterface wrappers
+@enable GeoInterface.Wrappers.WrapperGeometry
 
 end

--- a/GeoInterfaceRecipes/src/GeoInterfaceRecipes.jl
+++ b/GeoInterfaceRecipes/src/GeoInterfaceRecipes.jl
@@ -154,7 +154,7 @@ function expr_enable(typ)
 end
 
 """
-     GeoInterfaceRecipes.@enable(typ)
+     GeoInterfaceRecipes.@enable(GeometryType)
 
 Macro to add plot recipes to a geometry type.
 

--- a/GeoInterfaceRecipes/test/runtests.jl
+++ b/GeoInterfaceRecipes/test/runtests.jl
@@ -18,8 +18,9 @@ struct MyCollection{N} <: MyAbstractGeom{N} end
 struct MyFeature end
 struct MyFeatureCollection end
 
-GeoInterfaceRecipes.@enable_geo_plots MyAbstractGeom
-GeoInterfaceRecipes.@enable_geo_plots MyFeature
+GeoInterfaceRecipes.@enable MyAbstractGeom
+GeoInterfaceRecipes.@enable MyFeature
+# Test legacy interface
 GeoInterfaceRecipes.@enable_geo_plots MyFeatureCollection
 
 GeoInterface.isgeometry(::MyAbstractGeom) = true


### PR DESCRIPTION
This PR standardizes the `@enable` macro across GeoInterfaceRecipes and GeoInterfaceMakie (mostly to follow GeoInterfaceMakie, its cleaner). The `@enable_geo_plots` macro is kept for compat reasons.

It also applies both `@enable` macros to GeoInterface.Wrappers geometries - this seems to be the only place we can do that given the dependency structure.
