### PR TITLE
Use GI.convert for Makie plots, allow arrays

### DIFF
--- a/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
+++ b/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
@@ -18,13 +18,6 @@ end
 function plottype_from_geomtrait(::Union{GI.PolygonTrait,GI.MultiPolygonTrait, GI.LinearRingTrait})
     MC.Poly
 end
-function pttype(geom)
-    if GI.is3d(geom)
-        GB.Point3{Float64}
-    else
-        GB.Point2{Float64}
-    end
-end
 
 function _convert_arguments(t, geom)::Tuple
     geob = GI.convert(GB, geom)

--- a/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
+++ b/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
@@ -20,12 +20,12 @@ function plottype_from_geomtrait(::Union{GI.PolygonTrait,GI.MultiPolygonTrait, G
 end
 function pttype(geom)
     if GI.is3d(geom)
-        GB.Point3f
+        GB.Point3{Float64}
     else
-        GB.Point2f
+        GB.Point2{Float64}
     end
 end
-function points(geom)::Union{Vector{GB.Point2f}, Vector{GB.Point3f}}
+function points(geom)::Union{Vector{GB.Point2{Float64}}, Vector{GB.Point3{Float64}}}
     Pt = pttype(geom)
     out = Pt[]
     points!(out, GI.geomtrait(geom), geom)
@@ -40,13 +40,13 @@ end
     push!(out, _convert(eltype(out), pt))
     out
 end
-function _convert(::Type{GB.Point2f}, pt)
+function _convert(::Type{GB.Point2{Float64}, pt)
     x,y = GI.getcoord(pt)
-    GB.Point2f(x,y)
+    GB.Point2{Float64}(x,y)
 end
-function _convert(::Type{GB.Point3f}, pt)
+function _convert(::Type{GB.Point3{Float64}}, pt)
     x,y,z = GI.getcoord(pt)
-    GB.Point3f(x,y,z)
+    GB.Point3{Float64}(x,y,z)
 end
 
 function basicsgeom(geom)
@@ -83,11 +83,20 @@ function expr_enable(Geom)
         function $MC.convert_arguments(p::Type{<:$MC.Poly}, geom::$Geom)
             $_convert_arguments(p,geom)
         end
+        function $MC.convert_arguments(p::Type{<:$MC.Poly}, geom::AbstractArray{<: $Geom})
+            $_convert_arguments.((p,),geom)
+        end
         function $MC.convert_arguments(p::$MC.PointBased, geom::$Geom)
             $_convert_arguments(p,geom)
         end
+        function $MC.convert_arguments(p::$MC.PointBased, geom::AbstractArray{<: $Geom})
+            $_convert_arguments.((p,),geom)
+        end
         function $MC.convert_arguments(p::Type{<:$MC.Lines}, geom::$Geom)
             $_convert_arguments(p,geom)
+        end
+        function $MC.convert_arguments(p::Type{<:$MC.Lines}, geom::AbstractArray{<: $Geom})
+            $_convert_arguments.((p,),geom)
         end
     end
 end

--- a/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
+++ b/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
@@ -80,23 +80,26 @@ function expr_enable(Geom)
         function $MC.plottype(geom::$Geom)
             $_plottype(geom)
         end
-        function $MC.convert_arguments(p::Type{<:$MC.Poly}, geom::$Geom)
-            $_convert_arguments(p,geom)
+        function $MC.plottype(geoms::AbstractVector{<:$Geom})
+            $_plottype(first(geoms))
         end
-        function $MC.convert_arguments(p::Type{<:$MC.Poly}, geom::AbstractArray{<: $Geom})
-            $_convert_arguments.((p,),geom)
+        function $MC.convert_arguments(p::Type{<:$MC.Poly}, geom::$Geom)
+            $_convert_arguments(p, geom)
+        end
+        function $MC.convert_arguments(p::Type{<:$MC.Poly}, geoms::AbstractArray{<:$Geom})
+            $_convert_arguments.((p,), geoms)
         end
         function $MC.convert_arguments(p::$MC.PointBased, geom::$Geom)
-            $_convert_arguments(p,geom)
+            $_convert_arguments(p, geom)
         end
-        function $MC.convert_arguments(p::$MC.PointBased, geom::AbstractArray{<: $Geom})
-            $_convert_arguments.((p,),geom)
+        function $MC.convert_arguments(p::$MC.PointBased, geoms::AbstractArray{<:$Geom})
+            $_convert_arguments.((p,), geoms)
         end
         function $MC.convert_arguments(p::Type{<:$MC.Lines}, geom::$Geom)
-            $_convert_arguments(p,geom)
+            $_convert_arguments(p, geom)
         end
-        function $MC.convert_arguments(p::Type{<:$MC.Lines}, geom::AbstractArray{<: $Geom})
-            $_convert_arguments.((p,),geom)
+        function $MC.convert_arguments(p::Type{<:$MC.Lines}, geoms::AbstractArray{<:$Geom})
+            $_convert_arguments.((p,), geoms)
         end
     end
 end

--- a/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
+++ b/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
@@ -25,54 +25,14 @@ function pttype(geom)
         GB.Point2{Float64}
     end
 end
-function points(geom)::Union{Vector{GB.Point2{Float64}}, Vector{GB.Point3{Float64}}}
-    Pt = pttype(geom)
-    out = Pt[]
-    points!(out, GI.geomtrait(geom), geom)
-end
-@noinline function points!(out, ::GI.AbstractTrait, geom)
-    for pt in GI.getpoint(geom)
-        push!(out, _convert(eltype(out), pt))
-    end
-    out
-end
-@noinline function points!(out, ::GI.PointTrait, pt)
-    push!(out, _convert(eltype(out), pt))
-    out
-end
-function _convert(::Type{GB.Point2{Float64}}, pt)
-    x,y = GI.getcoord(pt)
-    GB.Point2{Float64}(x,y)
-end
-function _convert(::Type{GB.Point3{Float64}}, pt)
-    x,y,z = GI.getcoord(pt)
-    GB.Point3{Float64}(x,y,z)
-end
 
-function basicsgeom(geom)
-    t = GI.geomtrait(geom)
-    T = basicsgeomtype(t)
-    GI.convert(T, t, geom)
-end
-
-basicsgeomtype(::GI.PointTrait)           = GB.Point
-basicsgeomtype(::GI.MultiPointTrait)      = GB.MultiPoint
-basicsgeomtype(::GI.PolygonTrait)         = GB.Polygon
-basicsgeomtype(::GI.MultiPolygonTrait)    = GB.MultiPolygon
-basicsgeomtype(::GI.LineStringTrait)      = GB.LineString
-basicsgeomtype(::GI.MultiLineStringTrait) = GB.MultiLineString
-
-function _convert_arguments(t::Type{<:MC.Poly}, geom)::Tuple
-    geob = basicsgeom(geom)::Union{GB.Polygon, GB.MultiPolygon}
-    MC.convert_arguments(t,geob)
-end
-function _convert_arguments(t::Type{<:MC.Lines}, geom)::Tuple
-    geob = basicsgeom(geom)
+function _convert_arguments(t, geom)::Tuple
+    geob = GI.convert(GB, geom)
     MC.convert_arguments(t, geob)
 end
-function _convert_arguments(::MC.PointBased, geom)::Tuple
-    pts = points(geom)
-    (pts,)
+function _convert_array_arguments(t, geoms)::Tuple
+    geob = map(geom -> GI.convert(GB, geom), geoms)
+    MC.convert_arguments(t, geob)
 end
 
 function expr_enable(Geom)
@@ -80,26 +40,27 @@ function expr_enable(Geom)
         function $MC.plottype(geom::$Geom)
             $_plottype(geom)
         end
-        function $MC.plottype(geoms::AbstractVector{<:$Geom})
-            $_plottype(first(geoms))
+        # TODO: this method doesn't seem to do anything
+        function $MC.plottype(geom::AbstractArray{<:$Geom})
+            $_plottype(first(geom))
         end
         function $MC.convert_arguments(p::Type{<:$MC.Poly}, geom::$Geom)
             $_convert_arguments(p, geom)
         end
         function $MC.convert_arguments(p::Type{<:$MC.Poly}, geoms::AbstractArray{<:$Geom})
-            $_convert_arguments.((p,), geoms)
+            $_convert_array_arguments(p, geoms)
         end
         function $MC.convert_arguments(p::$MC.PointBased, geom::$Geom)
             $_convert_arguments(p, geom)
         end
         function $MC.convert_arguments(p::$MC.PointBased, geoms::AbstractArray{<:$Geom})
-            $_convert_arguments.((p,), geoms)
+            $_convert_array_arguments(p, geoms)
         end
         function $MC.convert_arguments(p::Type{<:$MC.Lines}, geom::$Geom)
             $_convert_arguments(p, geom)
         end
         function $MC.convert_arguments(p::Type{<:$MC.Lines}, geoms::AbstractArray{<:$Geom})
-            $_convert_arguments.((p,), geoms)
+            $_convert_array_arguments(p, geoms)
         end
     end
 end

--- a/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
+++ b/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
@@ -40,7 +40,7 @@ end
     push!(out, _convert(eltype(out), pt))
     out
 end
-function _convert(::Type{GB.Point2{Float64}, pt)
+function _convert(::Type{GB.Point2{Float64}}, pt)
     x,y = GI.getcoord(pt)
     GB.Point2{Float64}(x,y)
 end

--- a/GeoInterfaceMakie/test/runtests.jl
+++ b/GeoInterfaceMakie/test/runtests.jl
@@ -44,8 +44,9 @@ end
         readgeom("POINT(1 0)"),
         readgeom("MULTIPOINT(1 2, 2 3, 3 4)"),
     ]
-    for (i,geom) in enumerate(geoms)
+    for (i, geom) in enumerate(geoms)
         Makie.plot!(Axis(fig[i,1], title="$(GI.geomtrait(geom))"), geom)
+        Makie.plot!(Axis(fig[i,1], title="$(GI.geomtrait(geom))"), [geom])
     end
     fig
 end

--- a/GeoInterfaceMakie/test/runtests.jl
+++ b/GeoInterfaceMakie/test/runtests.jl
@@ -45,8 +45,8 @@ end
         readgeom("MULTIPOINT(1 2, 2 3, 3 4)"),
     ]
     for (i, geom) in enumerate(geoms)
-        Makie.plot!(Axis(fig[i,1], title="$(GI.geomtrait(geom))"), geom)
-        Makie.plot!(Axis(fig[i,1], title="$(GI.geomtrait(geom))"), [geom])
+        Makie.plot!(Axis(fig[i, 1], title="$(GI.geomtrait(geom))"), geom)
+        Makie.plot!(Axis(fig[i, 2], title="Vector of $(GI.geomtrait(geom))"), [geom])
     end
     fig
 end

--- a/GeoInterfaceMakie/test/runtests.jl
+++ b/GeoInterfaceMakie/test/runtests.jl
@@ -7,21 +7,6 @@ using Makie
 
 GeoInterfaceMakie.@enable(LibGEOS.AbstractGeometry)
 
-@testset "points" begin
-    points = GeoInterfaceMakie.points
-    pt = LibGEOS.Point(1,2,3)
-    @test points(pt) == [Point3f(1,2,3)]
-
-    unitsquare = readgeom("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))")
-    @test points(unitsquare) == [
-        Point2f(0.0, 0.0),
-        Point2f(0.0, 1.0),
-        Point2f(1.0, 1.0),
-        Point2f(1.0, 0.0),
-        Point2f(0.0, 0.0),
-    ]
-end
-
 @testset "Makie plotting LibGEOS MultiLineString shows additional lines #83" begin
     mls = readgeom("MULTILINESTRING ((0 0,3 0,3 3,0 3,0 0),(1 1,2 1,2 2,1 2,1 1))")
     expected = [[0.0, 0.0], [3.0, 0.0], [3.0, 3.0], [0.0, 3.0], [0.0, 0.0], 
@@ -35,18 +20,30 @@ end
     unitsquare = readgeom("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))")
     bigsquare = readgeom("POLYGON((0 0, 11 0, 11 11, 0 11, 0 0))")
     smallsquare = readgeom("POLYGON((5 5, 8 5, 8 8, 5 8, 5 5))")
-    fig = Figure()
+    multipolygon = GI.union(smallsquare, unitsquare)
+    point = readgeom("POINT(1 0)")
+    multipoint = readgeom("MULTIPOINT(1 2, 2 3, 3 4)")
     geoms = [
         unitsquare,
         GI.difference(bigsquare, smallsquare),
         boundary(unitsquare),
-        GI.union(smallsquare, unitsquare),
-        readgeom("POINT(1 0)"),
-        readgeom("MULTIPOINT(1 2, 2 3, 3 4)"),
+        multipolygon, 
+        point, 
+        multipoint,
     ]
+    fig = Figure()
     for (i, geom) in enumerate(geoms)
         Makie.plot!(Axis(fig[i, 1], title="$(GI.geomtrait(geom))"), geom)
-        Makie.plot!(Axis(fig[i, 2], title="Vector of $(GI.geomtrait(geom))"), [geom])
+        if geom == multipoint
+            # `plot!` wont even work with the GeometryBasics version of this
+            continue
+        elseif geom == multipolygon
+            # `plot!` wont work with the GeometryBasics version of this either
+            # But `poly!` does
+            Makie.poly!(Axis(fig[i, 2], title="Vector of $(GI.geomtrait(geom))"), [geom, geom])
+        else
+            Makie.plot!(Axis(fig[i, 2], title="Vector of $(GI.geomtrait(geom))"), [geom, geom])
+        end
     end
     fig
 end


### PR DESCRIPTION
@asinghvi17 I took the liberty of making a PR from your branch, I have this array code somewhere too but we may as well merge this instead. `Float64` is also better for high resolution things, going on the FLoat32 artifacts we see at high zooms in Tyler.jl....

~~A test of plotting the vectors could help I guess~~ done