### PR TITLE
Add crs is nothing fallback for non-geointerface types

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -95,7 +95,8 @@ issimple(t::AbstractMultiPointTrait, geom) = allunique((getgeom(t, geom)))
 issimple(t::AbstractMultiCurveTrait, geom) = all(issimple.(getgeom(t, geom)))
 isclosed(t::AbstractMultiCurveTrait, geom) = all(isclosed.(getgeom(t, geom)))
 
-crs(trait, geom) = nothing
+crs(::Nothing, geom) = nothing
+crs(::AbstractTrait, geom) = nothing
 
 # FeatureCollection
 getfeature(t::AbstractFeatureCollectionTrait, fc) = (getfeature(t, fc, i) for i in 1:nfeature(t, fc))

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -95,7 +95,7 @@ issimple(t::AbstractMultiPointTrait, geom) = allunique((getgeom(t, geom)))
 issimple(t::AbstractMultiCurveTrait, geom) = all(issimple.(getgeom(t, geom)))
 isclosed(t::AbstractMultiCurveTrait, geom) = all(isclosed.(getgeom(t, geom)))
 
-crs(::AbstractTrait, geom) = nothing
+crs(trait, geom) = nothing
 
 # FeatureCollection
 getfeature(t::AbstractFeatureCollectionTrait, fc) = (getfeature(t, fc, i) for i in 1:nfeature(t, fc))

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -478,6 +478,11 @@ end
 
 end
 
+@testset "extent and crs fallback to nothing on unknown objects" begin
+    @test isnothing(GeoInterface.crs(nothing))
+    @test isnothing(GeoInterface.extent(nothing))
+end
+
 module ConvertTestModule
 using GeoInterface
 struct TestPolygon end


### PR DESCRIPTION
This PR loosens the type in the `crs` fallback so that `crs(x) == nothing` for non geointerface `x`.

It also tests this fallback for both `crs` and `extent`

edit:
```julia
# Current behaviour
julia> GeoInterface.crs(1)
ERROR: MethodError: no method matching crs(::Nothing, ::Int64)
```