### PR TITLE
allow missing in arrays for Makie plots

### DIFF
--- a/GeoInterfaceMakie/Project.toml
+++ b/GeoInterfaceMakie/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoInterfaceMakie"
 uuid = "0edc0954-3250-4c18-859d-ec71c1660c08"
 authors = ["JuliaGeo and contributors"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"

--- a/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
+++ b/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
@@ -29,34 +29,55 @@ function _convert_array_arguments(t, geoms::AbstractArray{T})::Tuple where T
     else
         geob = map(geom -> GI.convert(GB, geom), geoms)
     end
-    MC.convert_arguments(t, geob)
+    return MC.convert_arguments(t, geob)
 end
 
 function expr_enable(Geom)
     quote
+        # plottype
         function $MC.plottype(geom::$Geom)
             $_plottype(geom)
         end
-        # TODO: this method doesn't seem to do anything
-        function $MC.plottype(geom::AbstractArray{<:Union{Missing,<:$Geom}})
+        function $MC.plottype(geom::AbstractArray{<:$Geom})
             $_plottype(first(geom))
         end
-        function $MC.convert_arguments(p::Type{<:$MC.Poly}, geom::$Geom)
+        function $MC.plottype(geom::AbstractArray{<:Union{Missing,<:$Geom}})
+            $_plottype(first(skipmissing(geom)))
+        end
+        # we need `AbstractVector` specifically for dispatch
+        function $MC.plottype(geom::AbstractVector{<:$Geom})
+            $_plottype(first(geom))
+        end
+        function $MC.plottype(geom::AbstractVector{<:Union{Missing,<:$Geom}})
+            $_plottype(first(skipmissing(geom)))
+        end
+
+        # convert_arguments
+        function $MC.convert_arguments(p::Type{<:$MC.Poly}, geom::$Geom; kw...)
             $_convert_arguments(p, geom)
         end
-        function $MC.convert_arguments(p::Type{<:$MC.Poly}, geoms::AbstractArray{<:Union{Missing,<:$Geom}})
+        function $MC.convert_arguments(p::Type{<:$MC.Poly}, geoms::AbstractArray{<:$Geom}; kw...)
             $_convert_array_arguments(p, geoms)
         end
-        function $MC.convert_arguments(p::$MC.PointBased, geom::$Geom)
-            $_convert_arguments(p, geom)
-        end
-        function $MC.convert_arguments(p::$MC.PointBased, geoms::AbstractArray{<:Union{Missing,<:$Geom}})
+        function $MC.convert_arguments(p::Type{<:$MC.Poly}, geoms::AbstractArray{<:Union{Missing,<:$Geom}}; kw...)
             $_convert_array_arguments(p, geoms)
         end
-        function $MC.convert_arguments(p::Type{<:$MC.Lines}, geom::$Geom)
+        function $MC.convert_arguments(p::$MC.PointBased, geom::$Geom; kw...)
             $_convert_arguments(p, geom)
         end
-        function $MC.convert_arguments(p::Type{<:$MC.Lines}, geoms::AbstractArray{<:Union{Missing,<:$Geom}})
+        function $MC.convert_arguments(p::$MC.PointBased, geoms::AbstractArray{<:$Geom}; kw...)
+            $_convert_array_arguments(p, geoms)
+        end
+        function $MC.convert_arguments(p::$MC.PointBased, geoms::AbstractArray{<:Union{Missing,<:$Geom}}; kw...)
+            $_convert_array_arguments(p, geoms)
+        end
+        function $MC.convert_arguments(p::Type{<:$MC.Lines}, geom::$Geom; kw...)
+            $_convert_arguments(p, geom)
+        end
+        function $MC.convert_arguments(p::Type{<:$MC.Lines}, geoms::AbstractArray{<:$Geom}; kw...)
+            $_convert_array_arguments(p, geoms)
+        end
+        function $MC.convert_arguments(p::Type{<:$MC.Lines}, geoms::AbstractArray{<:Union{Missing,<:$Geom}}; kw...)
             $_convert_array_arguments(p, geoms)
         end
     end

--- a/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
+++ b/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
@@ -23,8 +23,12 @@ function _convert_arguments(t, geom)::Tuple
     geob = GI.convert(GB, geom)
     MC.convert_arguments(t, geob)
 end
-function _convert_array_arguments(t, geoms)::Tuple
-    geob = map(geom -> GI.convert(GB, geom), geoms)
+function _convert_array_arguments(t, geoms::AbstractArray{T})::Tuple where T
+    if Missing <: T
+        geob = map(geom -> GI.convert(GB, geom), skipmissing(geoms))
+    else
+        geob = map(geom -> GI.convert(GB, geom), geoms)
+    end
     MC.convert_arguments(t, geob)
 end
 
@@ -34,25 +38,25 @@ function expr_enable(Geom)
             $_plottype(geom)
         end
         # TODO: this method doesn't seem to do anything
-        function $MC.plottype(geom::AbstractArray{<:$Geom})
+        function $MC.plottype(geom::AbstractArray{<:Union{Missing,<:$Geom}})
             $_plottype(first(geom))
         end
         function $MC.convert_arguments(p::Type{<:$MC.Poly}, geom::$Geom)
             $_convert_arguments(p, geom)
         end
-        function $MC.convert_arguments(p::Type{<:$MC.Poly}, geoms::AbstractArray{<:$Geom})
+        function $MC.convert_arguments(p::Type{<:$MC.Poly}, geoms::AbstractArray{<:Union{Missing,<:$Geom}})
             $_convert_array_arguments(p, geoms)
         end
         function $MC.convert_arguments(p::$MC.PointBased, geom::$Geom)
             $_convert_arguments(p, geom)
         end
-        function $MC.convert_arguments(p::$MC.PointBased, geoms::AbstractArray{<:$Geom})
+        function $MC.convert_arguments(p::$MC.PointBased, geoms::AbstractArray{<:Union{Missing,<:$Geom}})
             $_convert_array_arguments(p, geoms)
         end
         function $MC.convert_arguments(p::Type{<:$MC.Lines}, geom::$Geom)
             $_convert_arguments(p, geom)
         end
-        function $MC.convert_arguments(p::Type{<:$MC.Lines}, geoms::AbstractArray{<:$Geom})
+        function $MC.convert_arguments(p::Type{<:$MC.Lines}, geoms::AbstractArray{<:Union{Missing,<:$Geom}})
             $_convert_array_arguments(p, geoms)
         end
     end

--- a/GeoInterfaceMakie/test/runtests.jl
+++ b/GeoInterfaceMakie/test/runtests.jl
@@ -47,3 +47,8 @@ end
     end
     fig
 end
+
+@testset "handle missing values" begin
+    geoms = [GI.Point(1, 2), GI.Point(3, 4), missing]
+    Makie.plot(geoms)
+end

--- a/GeoInterfaceMakie/test/runtests.jl
+++ b/GeoInterfaceMakie/test/runtests.jl
@@ -49,6 +49,8 @@ end
 end
 
 @testset "handle missing values" begin
-    geoms = [GI.Point(1, 2), GI.Point(3, 4), missing]
-    Makie.plot(geoms)
+    points = [GI.Point(1, 2), GI.Point(3, 4), missing]
+    Makie.plot(points)
+    lines = [GI.LineString([(1, 2), (3, 4)]), GI.LineString([(5, 4), (5, 6)]), missing]
+    Makie.plot(lines)
 end


### PR DESCRIPTION
Minor change to allow `missing` in GeoInterfaceMakie plots. 

This is needed for Shapefile.jl makie recipes.