### PR TITLE
Add `ncoord` for arbitrary `WrapperGeometry`

### DIFF
--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -63,6 +63,7 @@ abstract type WrapperGeometry{Z,M,T,C} end
 isgeometry(::Type{<:WrapperGeometry}) = true
 is3d(::WrapperGeometry{Z}) where Z = Z
 ismeasured(::WrapperGeometry{<:Any,M})  where M = M
+ncoord(::WrapperGeometry{Z, M}) where {Z, M} = 2 + Z + M
 
 Base.parent(geom::WrapperGeometry) = geom.geom
 


### PR DESCRIPTION
This does actually compile down, see:
```julia
julia> x = GI.Point(1, 2, 3, 4)
GeoInterface.Wrappers.Point{true, true, NTuple{4, Int64}, Nothing}((1, 2, 3, 4), nothing)

julia> @code_typed GI.ncoord(x)
CodeInfo(
1 ─     return 4
) => Int64
```

cc @rafaqz 