### PR TITLE
Add a 1-arg curried version of `GI.convert`

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -634,9 +634,14 @@ Create a `CustomGeom` from any `geom` that implements the GeoInterface.
 
 Can also convert to a `Module`, which finds the corresponding
 geom type for the trait using the modules `geointerface_traittype` method.
+
+`convert(T::Type)` or `convert(m::Module)` return curried versions of that function, 
+just like `==`.
 """
 convert(T, geom) = convert(T, geomtrait(geom), geom)
 convert(::Type{T}, x::T) where {T} = x  # no-op
+convert(T::Type) = Base.Fix1(convert, T)
+convert(M::Module) = Base.Fix1(convert, M)
 
 """
     astext(geom) -> WKT

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -257,6 +257,9 @@ end
     geom = MyCurve()
     @test GeoInterface.convert(MyCurve, geom) === geom
     @test_throws Exception GeoInterface.convert(MyPolygon, geom)
+    @test GeoInterface.convert(MyCurve)(geom) == geom
+    @test_throws Exception GeoInterface.convert(MyPolygon)(geom)
+    
 end
 
 @testset "Operations" begin
@@ -499,7 +502,9 @@ module BadModule
 end
 
 @test GeoInterface.convert(ConvertTestModule, MyPolygon()) == ConvertTestModule.TestPolygon()
+@test GeoInterface.convert(ConvertTestModule)(MyPolygon()) == ConvertTestModule.TestPolygon()
 @test_throws ArgumentError GeoInterface.convert(BadModule, MyPolygon()) == ConvertTestModule.TestPolygon()
+@test_throws ArgumentError GeoInterface.convert(BadModule)(MyPolygon()) == ConvertTestModule.TestPolygon()
 
 
 struct ExtentPolygon end


### PR DESCRIPTION
I was doing some data processing and having `|> GI.convert(LibGEOS) |> ...` would have been handy, so I coded this up.