### PR TITLE
Allow vectors with mixed single and multi geometries to be plotted in Makie

### DIFF
--- a/GeoInterfaceMakie/Project.toml
+++ b/GeoInterfaceMakie/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoInterfaceMakie"
 uuid = "0edc0954-3250-4c18-859d-ec71c1660c08"
 authors = ["JuliaGeo and contributors"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"

--- a/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
+++ b/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
@@ -144,6 +144,12 @@ to_multipoly(::Nothing, geom::AbstractVector) = to_multipoly.(GeoInterface.trait
 to_multipoly(::GeoInterface.PolygonTrait, geom) = GB.MultiPolygon([GeoInterface.convert(GB, geom)])
 to_multipoly(::GeoInterface.MultiPolygonTrait, geom) = GeoInterface.convert(GB, geom)
 
+function to_multipoly(::GeoInterface.GeometryCollectionTrait, geom)
+    ls_or_mls = filter(x -> GI.geomtrait(x) isa Union{GI.MultiPolygonTrait, GI.PolygonTrait}, GI.getgeom(geom))
+    multipolys = to_multipoly(ls_or_mls)
+    return GeometryBasics.MultiPolygon(vcat(getproperty.(multipolys, :polys)...))
+end
+
 to_multilinestring(poly::GB.LineString) = GB.MultiLineString([poly])
 to_multilinestring(poly::Vector{GB.Polygon}) = GB.MultiLineString(poly)
 to_multilinestring(mp::GB.MultiLineString) = mp
@@ -151,6 +157,12 @@ to_multilinestring(geom) = to_multilinestring(GeoInterface.trait(geom), geom)
 to_multilinestring(geom::AbstractVector) = to_multilinestring.(GeoInterface.trait.(geom), geom)
 to_multilinestring(::GeoInterface.LineStringTrait, geom) = GB.MultiLineString([GeoInterface.convert(GB, geom)])
 to_multilinestring(::GeoInterface.MultiLineStringTrait, geom) = GeoInterface.convert(GB, geom)
+
+function to_multilinestring(::GeoInterface.GeometryCollectionTrait, geom)
+    ls_or_mls = filter(x -> GI.geomtrait(x) isa Union{GI.MultiLineStringTrait, GI.LineStringTrait}, GI.getgeom(geom))
+    multilinestrings = to_multilinestring(ls_or_mls)
+    return GeometryBasics.MultiLineString(vcat(getproperty.(multilinestrings, :linestrings)...))
+end
 
 to_multipoint(poly::GB.Point) = GB.MultiPoint([poly])
 to_multipoint(poly::Vector{GB.Point}) = GB.MultiPoint(poly)

--- a/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
+++ b/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
@@ -41,9 +41,9 @@ function _convert_array_arguments(t, geoms::AbstractArray{T})::Tuple where T
             # It's possible that the point lengths are different, we still need to handle that.
             return MC.convert_arguments(t, geob)
         end
-        if all(x -> GI.geomtrait(x) isa Union{GI.MultiPolygonTrait, GI.PolygonTrait}, geob) # an array of polygon like structs
+        if all(x -> GI.geomtrait(x) isa Union{GI.MultiPolygonTrait, GI.PolygonTrait, GI.GeometryCollectionTrait}, geob) # an array of polygon like structs
             geob = to_multipoly(geob)
-        elseif all(x -> GI.geomtrait(x) isa Union{GI.MultiLineStringTrait, GI.LineStringTrait}, geob) # an array of linestring like structs
+        elseif all(x -> GI.geomtrait(x) isa Union{GI.MultiLineStringTrait, GI.LineStringTrait, GI.GeometryCollectionTrait}, geob) # an array of linestring like structs
             geob = to_multilinestring(geob)
         end
     end

--- a/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
+++ b/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
@@ -9,7 +9,7 @@ import GeoInterface as GI
 function _plottype(geom)
     plottype_from_geomtrait(GI.geomtrait(geom))
 end
-function plottype_from_geomtrait(::Union{GI.LineStringTrait, GI.MultiLineStringTrait})
+function plottype_from_geomtrait(::Union{GI.LineStringTrait, GI.MultiLineStringTrait, GI.GeometryCollectionTrait})
     MC.Lines
 end
 function plottype_from_geomtrait(::Union{GI.PointTrait, GI.MultiPointTrait})

--- a/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
+++ b/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
@@ -36,7 +36,10 @@ function _convert_array_arguments(t, geoms::AbstractArray{T})::Tuple where T
         end
         first_trait = GI.geomtrait(first(geob))
         last_trait = GI.geomtrait(last(geob))
-        if first_trait isa GI.PolygonTrait || first_trait isa GI.MultiPolygonTrait
+        if first_trait == last_trait
+            # This should never happen, if the traits are the same, unless the dimensions are wrong.
+            # error("GeoInterfaceMakie: Geometry traits are the same, this should never happen.")
+        elseif first_trait isa GI.PolygonTrait || first_trait isa GI.MultiPolygonTrait
             if last_trait isa GI.PolygonTrait || last_trait isa GI.MultiPolygonTrait
                 geob = to_multipoly(geob)
             end

--- a/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
+++ b/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
@@ -31,8 +31,8 @@ function _convert_array_arguments(t, geoms::AbstractArray{T})::Tuple where T
         geob = map(geom -> GI.convert(GB, geom), geoms)
     end
     if !(eltype(geob) <: GB.AbstractGeometry) || eltype(geob) isa Union # Unions are bad
-        if isempty(geob)
-            geob = geob
+        if isempty(geob) # this means that an empty vector with some eltype was passed in...
+            return geob
         end
         first_trait = GI.geomtrait(first(geob))
         different_trait_idx = findfirst(x -> GI.geomtrait(x) != first_trait, geob)
@@ -42,9 +42,9 @@ function _convert_array_arguments(t, geoms::AbstractArray{T})::Tuple where T
             return MC.convert_arguments(t, geob)
         end
         if all(x -> GI.geomtrait(x) isa Union{GI.MultiPolygonTrait, GI.PolygonTrait, GI.GeometryCollectionTrait}, geob) # an array of polygon like structs
-            geob = to_multipoly(geob)
+            return MC.convert_arguments(t, to_multipoly(geob))
         elseif all(x -> GI.geomtrait(x) isa Union{GI.MultiLineStringTrait, GI.LineStringTrait, GI.GeometryCollectionTrait}, geob) # an array of linestring like structs
-            geob = to_multilinestring(geob)
+            return MC.convert_arguments(t, to_multilinestring(geob))
         end
     end
     return MC.convert_arguments(t, geob)

--- a/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
+++ b/GeoInterfaceMakie/src/GeoInterfaceMakie.jl
@@ -44,10 +44,6 @@ function _convert_array_arguments(t, geoms::AbstractArray{T})::Tuple where T
             if last_trait isa GI.LineStringTrait || last_trait isa GI.MultiLineStringTrait
                 geob = to_multilinestring(geob)
             end
-        elseif first_trait isa GI.PointTrait || first_trait isa GI.MultiPointTrait
-            if last_trait isa GI.PointTrait || last_trait isa GI.MultiPointTrait
-                geob = to_multipoint(geob)
-            end
         end
     end
     return MC.convert_arguments(t, geob)

--- a/GeoInterfaceMakie/test/runtests.jl
+++ b/GeoInterfaceMakie/test/runtests.jl
@@ -26,7 +26,7 @@ end
     geoms = [
         unitsquare,
         GI.difference(bigsquare, smallsquare),
-        boundary(unitsquare),
+        LibGEOS.boundary(unitsquare),
         multipolygon, 
         point, 
         multipoint,

--- a/GeoInterfaceMakie/test/runtests.jl
+++ b/GeoInterfaceMakie/test/runtests.jl
@@ -59,4 +59,5 @@ end
     poly = GI.Polygon([GI.LinearRing([(0, 0), (1, 0), (1, 1), (0, 0)])])
     multipoly = GI.MultiPolygon([poly, poly])
     @test_nowarn Makie.plot([poly, multipoly])
+    @test_nowarn Makie.plot([GI.GeometryCollection([poly, multipoly]), multipoly])
 end

--- a/GeoInterfaceMakie/test/runtests.jl
+++ b/GeoInterfaceMakie/test/runtests.jl
@@ -54,3 +54,9 @@ end
     lines = [GI.LineString([(1, 2), (3, 4)]), GI.LineString([(5, 4), (5, 6)]), missing]
     Makie.plot(lines)
 end
+
+@testset "Mixed geometry types work" begin
+    poly = GI.Polygon([GI.LinearRing([(0, 0), (1, 0), (1, 1), (0, 0)])])
+    multipoly = GI.MultiPolygon([poly, poly])
+    @test_nowarn Makie.plot([poly, multipoly])
+end


### PR DESCRIPTION
This upstreams GeoMakie.to_multipoly and its variants into GeoInterfaceMakie.  Performance needs improvement but this is otherwise ready for review, and I have tested it works.

Usecase:

```julia
using NaturalEarth
using CairoMakie

fc = NaturalEarth.naturalearth("admin_0_countries", 10)
plot(fc.geometry)
```
without any fuss or muss.