### PR TITLE
Bump GeoInterface patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoInterface"
 uuid = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 authors = ["JuliaGeo and contributors"]
-version = "1.3.4"
+version = "1.3.5"
 
 [deps]
 Extents = "411431e0-e8b7-467b-b5e0-f676ba4f2910"


### PR DESCRIPTION
The 1-arg convert PR is still unreleased, wanted to release that.