### PR TITLE
Handle vectors with missings correctly in GeoInterfaceMakie

### DIFF
--- a/GeoInterfaceMakie/Project.toml
+++ b/GeoInterfaceMakie/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoInterfaceMakie"
 uuid = "0edc0954-3250-4c18-859d-ec71c1660c08"
 authors = ["JuliaGeo and contributors"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"

--- a/GeoInterfaceMakie/Project.toml
+++ b/GeoInterfaceMakie/Project.toml
@@ -16,8 +16,9 @@ julia = "1.6"
 
 [extras]
 LibGEOS = "a90b1aa1-3769-5649-ba7e-abc5a9d163eb"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "LibGEOS", "Makie"]
+test = ["Test", "CairoMakie", "Makie", "LibGEOS"]

--- a/GeoInterfaceMakie/test/runtests.jl
+++ b/GeoInterfaceMakie/test/runtests.jl
@@ -3,7 +3,8 @@ using Test
 import LibGEOS
 using LibGEOS
 import GeoInterface as GI
-using Makie
+using Makie, CairoMakie
+using Makie: Point2d
 
 GeoInterfaceMakie.@enable(LibGEOS.AbstractGeometry)
 
@@ -40,19 +41,29 @@ end
         elseif geom == multipolygon
             # `plot!` wont work with the GeometryBasics version of this either
             # But `poly!` does
-            Makie.poly!(Axis(fig[i, 2], title="Vector of $(GI.geomtrait(geom))"), [geom, geom])
+            @test_nowarn Makie.poly!(Axis(fig[i, 2], title="Vector of $(GI.geomtrait(geom))"), [geom, geom])
         else
-            Makie.plot!(Axis(fig[i, 2], title="Vector of $(GI.geomtrait(geom))"), [geom, geom])
+            @test_nowarn Makie.plot!(Axis(fig[i, 2], title="Vector of $(GI.geomtrait(geom))"), [geom, geom])
         end
     end
     fig
 end
 
-@testset "handle missing values" begin
-    points = [GI.Point(1, 2), GI.Point(3, 4), missing]
-    Makie.plot(points)
-    lines = [GI.LineString([(1, 2), (3, 4)]), GI.LineString([(5, 4), (5, 6)]), missing]
-    Makie.plot(lines)
+
+
+@testset "Make sure that Makie can plot NaN-based geometry correctly" begin
+    f, a, p = poly(Makie.GeometryBasics.Polygon([Point2f(NaN)]))
+    @test_nowarn Makie.update_state_before_display!(f)
+    @test_nowarn Makie.colorbuffer(f.scene)
+    @test a.finallimits[] == Makie.Rect2d(Vec2(0.0, 0.0), Vec2(10.0, 10.0))
+    # Hide all decorations so the scene should ideally be completely white
+    hidedecorations!(a)
+    hidespines!(a)
+    # Rasterize the figure's scene to an image
+    img = Makie.colorbuffer(f.scene)
+    # Test that everything is white, i.e., there is no color.
+    # This means that nothing was plotted, which is good.
+    @test all(==(Makie.ARGB32(1,1,1,1)), img)
 end
 
 @testset "Mixed geometry types work" begin
@@ -60,4 +71,19 @@ end
     multipoly = GI.MultiPolygon([poly, poly])
     @test_nowarn Makie.plot([poly, multipoly])
     @test_nowarn Makie.plot([GI.GeometryCollection([poly, multipoly]), multipoly])
+end
+
+@testset "handle missing values" begin
+    # First test that missing values get the right dispatches
+    points = [GI.Point(1, 2), GI.Point(3, 4), missing]
+    @test_nowarn Makie.plot(points)
+    lines = [GI.LineString([(1, 2), (3, 4)]), GI.LineString([(5, 4), (5, 6)]), missing]
+    @test_nowarn Makie.plot(lines)
+    polys = [GI.Polygon([GI.LinearRing(Point2d[(1, 2), (3, 4), (5, 5), (1, 2)])]), GI.Polygon([GI.LinearRing(Point2d[(7, 8), (9, 10), (11, 11), (7, 8)])]), missing]
+    @test_nowarn Makie.plot(polys)
+    # Now we test that appropriate "missing" (i.e., NaN) polygons 
+    # are inserted in the correct place, so that we have the same
+    # number of elements post conversion as pre conversion.  This
+    # allows colors to be propagated correctly through the array.
+    @test_nowarn Makie.poly(polys; color = 1:length(polys))
 end

--- a/GeoInterfaceMakie/test/runtests.jl
+++ b/GeoInterfaceMakie/test/runtests.jl
@@ -75,9 +75,9 @@ end
 
 @testset "handle missing values" begin
     # First test that missing values get the right dispatches
-    points = [GI.Point(1, 2), GI.Point(3, 4), missing]
+    points = [GI.Point(1., 2.), GI.Point(3., 4.), missing]
     @test_nowarn Makie.plot(points)
-    lines = [GI.LineString([(1, 2), (3, 4)]), GI.LineString([(5, 4), (5, 6)]), missing]
+    lines = [GI.LineString(Point2d[(1, 2), (3, 4)]), GI.LineString(Point2d[(5, 4), (5, 6)]), missing]
     @test_nowarn Makie.plot(lines)
     polys = [GI.Polygon([GI.LinearRing(Point2d[(1, 2), (3, 4), (5, 5), (1, 2)])]), GI.Polygon([GI.LinearRing(Point2d[(7, 8), (9, 10), (11, 11), (7, 8)])]), missing]
     @test_nowarn Makie.plot(polys)


### PR DESCRIPTION
This PR replaces missings with NaN geometries (not quite empty, but close).  The infrastructure to change types is all there but it needs some way to get the coordinate type from a geometry - this may be better implemented via the proposed `GI.coordtype` method.

Fixes #138 