### PR TITLE
[WIP] Add a fallback to `geometry` for FeatureCollections

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -52,7 +52,9 @@ geometrycolumns(featurecollection) = (:geometry,)
 Retrieve the geometry of `feat`. It is expected that `isgeometry(geom) === true`.
 Ensures backwards compatibility with GeoInterface version 0.
 """
-geometry(feat) = nothing
+geometry(feat) = geometry(trait(feat), feat)
+geometry(::Union{AbstractTrait, Nothing), feat) = nothing
+geometry(::FeatureCollectionTrait, fc) = Iterators.map(geometry, getfeature(fc))
 
 """
     GeoInterface.properties(feat) => properties


### PR DESCRIPTION
What do people think of this?

This enables:
```julia
tab = Shapefile.Table(...)
shapes = GI.geometry(tab)

# or, and more importantly,

tab = GeoJSON.read(...)
shapes = GI.geometry(tab)
```

This can always be customized for individual tables for efficiency's sake, but from a UI perspective I think this is a solid improvement over what we have now.