### PR TITLE
Better child error when creating geom from array

### DIFF
--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -186,10 +186,10 @@ for (geomtype, trait, childtype, child_trait, length_check, nesting) in (
         # Otherwise wrap an array of child geometries
         elseif geom isa AbstractArray
             child = first(geom)
-            chilren_match = all(child -> geomtrait(child) isa $child_trait, geom)
+            children_match = findfirst(child -> !(geomtrait(child) isa $child_trait), geom)
 
             # Where the next level down is the child geometry
-            if chilren_match
+            if isnothing(children_match)
                 if $(!isnothing(length_check))
                     $length_check(Base.length(geom)) || _length_error($geomtype, $length_check, geom)
                 end
@@ -219,7 +219,7 @@ for (geomtype, trait, childtype, child_trait, length_check, nesting) in (
                     end
                 end
                 # Otherwise compain the nested child type is wrong
-                _wrong_child_error($trait, $child_trait, child)
+                _wrong_child_error($trait, $child_trait, geom[children_match])
             end
         else
             # Or complain the parent type is wrong


### PR DESCRIPTION
When creating a geometry from an array that contains elements with the wrong trait, refer to the first element that has the wrong trait, rather than the first element of the array.

MWE:
```julia
import GeoInterface as GI
p = GI.Point(0,0)
x = 1
GI.Line([p, x])
```

Before this PR throws a

```
ERROR: ArgumentError: GeoInterface.LineTrait must have child objects with trait GeoInterface.PointTrait, got GeoInterface.Wrappers.Point{false, false, Tuple{Int64, Int64}, Nothing} with trait 
GeoInterface.PointTrait()
```

After this PR throws a: 
```
ERROR: ArgumentError: LineTrait must have child objects with trait PointTrait, got Int64 with trait nothing
```