### PR TITLE
skip nan in extent calculation

### DIFF
--- a/test/test_wrappers.jl
+++ b/test/test_wrappers.jl
@@ -301,6 +301,13 @@ fc = GI.FeatureCollection(fc_unwrapped.parent; crs=EPSG(4326), extent=GI.extent(
 vecfc = GI.FeatureCollection([(geometry=(1,2), a=1, b=2)])
 @test GI.getfeature(vecfc, 1) == (geometry=(1,2), a=1, b=2)
 
+@testset "Extent skips NaN" begin
+    nan_multipoint = GI.MultiPoint([(1.0, NaN), (3.0, 4.0), (3.0, 2.0), (NaN, 4.0), (7.0, 8.0), (9.0, 10.0)])
+    nan_polygon = GI.Polygon(GI.LineString([(1.0, NaN), (3.0, 4.0), (3.0, 2.0), (NaN, 4.0), (7.0, 8.0), (9.0, 10.0)]))
+    @test GI.extent(nan_multipoint) == Extent(X = (1.0, 9.0), Y = (2.0, 10.0))
+    @test GI.extent(nan_polygon) == Extent(X = (1.0, 9.0), Y = (2.0, 10.0))
+end
+
 # TODO
 
 # # Triangle


### PR DESCRIPTION
This PR fixes the problem where NaNs win over other coordinates to make `NaN` extents that don't work anywhere. Or do work in DimensionalData.jl and because `NaN` comparisons always return `false`, it just select the maximum possible extent.

To do this I switch `extrema` to `_nan_free_extrema`, which turns out to be faster anyway.