### PR TITLE
Correctly implement interface for wrapper geometry.

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,16 +12,17 @@ function testgeometry(geom)
 
     if type == PointTrait()
         n = ncoord(geom)
+        @assert n == ncoord(type, geom) "$geom does not correctly implement three argument `getcoord`"
         if n >= 1  # point could be empty
-            getcoord(geom, 1)  # point always needs at least 2
+            c = getcoord(geom, 1)  # point always needs at least 2
+            @assert c == getcoord(type, geom, 1) "$geom does not correctly implement three argument `getcoord`"
         end
-        @assert hasmethod(getcoord, (typeof(type), typeof(geom), Int)) "$geom does not correctly implement three argument `getcoord`"
     else
         n = ngeom(geom)
-        @assert hasmethod(ngeom, (typeof(type), typeof(geom))) "$geom does not correctly implement two argument `ngeom`"
-        @assert hasmethod(getgeom, (typeof(type), typeof(geom), Int)) "$geom does not correctly implement two argument `ngeom`"
+        @assert n == ngeom(type, geom) "$geom does not correctly implement two argument `ngeom`"
         if n >= 1  # geometry could be empty
             g2 = getgeom(geom, 1)
+            @assert g2 == getgeom(type, geom, 1) "$geom does not correctly implement three argument `getgeom`"
             subtype = subtrait(type)
             if !isnothing(subtype)
                 issub = geomtrait(g2) isa subtype

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,13 +8,18 @@ function testgeometry(geom)
     type = geomtrait(geom)
     @assert !isnothing(type) "$geom doesn't implement `geomtrait`."
 
+    @assert hasmethod(ncoord, (typeof(type), typeof(geom))) "$geom does not correctly implement two argument `ncoord`"
+
     if type == PointTrait()
         n = ncoord(geom)
         if n >= 1  # point could be empty
             getcoord(geom, 1)  # point always needs at least 2
         end
+        @assert hasmethod(getcoord, (typeof(type), typeof(geom), Int)) "$geom does not correctly implement three argument `getcoord`"
     else
         n = ngeom(geom)
+        @assert hasmethod(ngeom, (typeof(type), typeof(geom))) "$geom does not correctly implement two argument `ngeom`"
+        @assert hasmethod(getgeom, (typeof(type), typeof(geom), Int)) "$geom does not correctly implement two argument `ngeom`"
         if n >= 1  # geometry could be empty
             g2 = getgeom(geom, 1)
             subtype = subtrait(type)

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -61,9 +61,9 @@ measures.
 abstract type WrapperGeometry{Z,M,T,C} end
 
 isgeometry(::Type{<:WrapperGeometry}) = true
-is3d(::WrapperGeometry{Z}) where Z = Z
-ismeasured(::WrapperGeometry{<:Any,M})  where M = M
-ncoord(::WrapperGeometry{Z, M}) where {Z, M} = 2 + Z + M
+is3d(::AbstractGeometryTrait, ::WrapperGeometry{Z}) where Z = Z
+ismeasured(::AbstractGeometryTrait, ::WrapperGeometry{<:Any,M})  where M = M
+ncoord(::AbstractGeometryTrait, ::WrapperGeometry{Z, M}) where {Z, M} = 2 + Z + M
 
 Base.parent(geom::WrapperGeometry) = geom.geom
 


### PR DESCRIPTION
Fixes https://github.com/evetion/WellKnownGeometry.jl/issues/37.

Packages should implement the two argument interface methods for geometries, and #124 did not. In WKG I assumed I could call `ncoord(trait, geom)`, which failed.