### PR TITLE
Remove ambiguity and implement `getgeom`, `ngeom` for `Wrappers.Point`

### DIFF
--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -318,6 +318,10 @@ convert(::Type{Point}, ::PointTrait, geom) = Point(geom)
 convert(::Type{Point}, ::PointTrait, geom::Point) = geom
 extent(trait::PointTrait, geom::Point) = extent(trait, parent(geom)) 
 
+ngeom(::PointTrait, geom::Point) = 0
+getgeom(::PointTrait, geom::Point) = nothing
+getgeom(::PointTrait, geom::Point, i) = nothing
+
 x(trait::PointTrait, geom::Point) = x(trait, parent(geom))
 y(trait::PointTrait, geom::Point) = y(trait, parent(geom))
 z(trait::PointTrait, geom::Point{true}) = z(trait, parent(geom))


### PR DESCRIPTION
This was mentioned on Slack, the output is probably a bit better than a method ambiguity error now.