### PR TITLE
Test isgeometry on type of geometry.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoInterface"
 uuid = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 authors = ["JuliaGeo and contributors"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,6 +5,7 @@ Test whether the required interface for your `geom` has been implemented correct
 """
 function testgeometry(geom)
     @assert isgeometry(geom) "$geom doesn't implement `isgeometry`."
+    @assert isgeometry(typeof(geom)) "Type{$(typeof(geom))} doesn't implement `isgeometry`."
     type = geomtrait(geom)
     @assert !isnothing(type) "$geom doesn't implement `geomtrait`."
 

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -24,59 +24,59 @@ end
 
 struct Raster end
 
-GeoInterface.isgeometry(::MyPoint) = true
+GeoInterface.isgeometry(::Type{MyPoint}) = true
 GeoInterface.geomtrait(::MyPoint) = PointTrait()
 GeoInterface.ncoord(::PointTrait, geom::MyPoint) = 2
 GeoInterface.getcoord(::PointTrait, geom::MyPoint, i) = [1, 2][i]
 
-GeoInterface.isgeometry(::MyEmptyPoint) = true
+GeoInterface.isgeometry(::Type{MyEmptyPoint}) = true
 GeoInterface.geomtrait(::MyEmptyPoint) = PointTrait()
 GeoInterface.ncoord(::PointTrait, geom::MyEmptyPoint) = 0
 GeoInterface.isempty(::PointTrait, geom::MyEmptyPoint) = true
 
-GeoInterface.isgeometry(::MyCurve) = true
+GeoInterface.isgeometry(::Type{MyCurve}) = true
 GeoInterface.geomtrait(::MyCurve) = LineStringTrait()
 GeoInterface.ngeom(::LineStringTrait, geom::MyCurve) = 2
 GeoInterface.getgeom(::LineStringTrait, geom::MyCurve, i) = MyPoint()
 GeoInterface.ncoord(t::LineStringTrait, geom::MyCurve) = 2
 
-GeoInterface.isgeometry(::MyPolygon) = true
+GeoInterface.isgeometry(::Type{MyPolygon}) = true
 GeoInterface.geomtrait(::MyPolygon) = PolygonTrait()
 GeoInterface.ngeom(::PolygonTrait, geom::MyPolygon) = 2
 GeoInterface.getgeom(::PolygonTrait, geom::MyPolygon, i) = MyCurve()
 GeoInterface.ncoord(t::PolygonTrait, geom::MyPolygon) = 2
 
-GeoInterface.isgeometry(::MyTriangle) = true
+GeoInterface.isgeometry(::Type{MyTriangle}) = true
 GeoInterface.geomtrait(::MyTriangle) = TriangleTrait()
 GeoInterface.ngeom(::TriangleTrait, geom::MyTriangle) = 3
 GeoInterface.getgeom(::TriangleTrait, geom::MyTriangle, i) = MyCurve()
 GeoInterface.ncoord(t::TriangleTrait, geom::MyTriangle) = 2
 
-GeoInterface.isgeometry(::MyMultiPoint) = true
+GeoInterface.isgeometry(::Type{MyMultiPoint}) = true
 GeoInterface.geomtrait(::MyMultiPoint) = MultiPointTrait()
 GeoInterface.ngeom(::MultiPointTrait, geom::MyMultiPoint) = 2
 GeoInterface.getgeom(::MultiPointTrait, geom::MyMultiPoint, i) = MyPoint()
 GeoInterface.ncoord(t::MultiPointTrait, geom::MyMultiPoint) = 2
 
-GeoInterface.isgeometry(::MyMultiCurve) = true
+GeoInterface.isgeometry(::Type{MyMultiCurve}) = true
 GeoInterface.geomtrait(::MyMultiCurve) = MultiCurveTrait()
 GeoInterface.ngeom(::MultiCurveTrait, geom::MyMultiCurve) = 2
 GeoInterface.getgeom(::MultiCurveTrait, geom::MyMultiCurve, i) = MyCurve()
 GeoInterface.ncoord(t::MultiCurveTrait, geom::MyMultiCurve) = 2
 
-GeoInterface.isgeometry(::MyMultiPolygon) = true
+GeoInterface.isgeometry(::Type{MyMultiPolygon}) = true
 GeoInterface.geomtrait(::MyMultiPolygon) = MultiPolygonTrait()
 GeoInterface.ngeom(::MultiPolygonTrait, geom::MyMultiPolygon) = 2
 GeoInterface.getgeom(::MultiPolygonTrait, geom::MyMultiPolygon, i) = MyPolygon()
 GeoInterface.ncoord(t::MultiPolygonTrait, geom::MyMultiPolygon) = 2
 
-GeoInterface.isgeometry(::MyTIN) = true
+GeoInterface.isgeometry(::Type{MyTIN}) = true
 GeoInterface.geomtrait(::MyTIN) = PolyhedralSurfaceTrait()
 GeoInterface.ngeom(::PolyhedralSurfaceTrait, geom::MyTIN) = 2
 GeoInterface.getgeom(::PolyhedralSurfaceTrait, geom::MyTIN, i) = MyTriangle()
 GeoInterface.ncoord(t::PolyhedralSurfaceTrait, geom::MyTIN) = 2
 
-GeoInterface.isgeometry(::MyCollection) = true
+GeoInterface.isgeometry(::Type{MyCollection}) = true
 GeoInterface.geomtrait(::MyCollection) = GeometryCollectionTrait()
 GeoInterface.ngeom(::GeometryCollectionTrait, geom::MyCollection) = 2
 GeoInterface.getgeom(::GeometryCollectionTrait, geom::MyCollection, i) = MyCurve()
@@ -279,7 +279,7 @@ end
 @testset "Operations" begin
     struct XGeom end
 
-    GeoInterface.isgeometry(::XGeom) = true
+    GeoInterface.isgeometry(::Type{XGeom}) = true
     GeoInterface.geomtrait(::XGeom) = PointTrait()
     GeoInterface.ncoord(::PointTrait, geom::XGeom) = 2
     GeoInterface.getcoord(::PointTrait, geom::XGeom, i) = [1, 2][i]


### PR DESCRIPTION
The interface actually tells you to do so, but it's easy to forget/skip. Found this for `isgeometry(GFT.WellKnownBinary)` (blessed piracy in [WellKnownGeometry](https://github.com/evetion/WellKnownGeometry.jl/pull/41)) when working on [GeoArrow](https://github.com/JuliaGeo/GeoArrow.jl/pull/2) purely based on the types of a column (not the first instance or similar).