### PR TITLE
Fix `UndefVarError` in `nfeature` and `getfeature`

### DIFF
--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -652,9 +652,9 @@ _child_feature_error() = throw(ArgumentError("child objects must be features"))
 isfeaturecollection(fc::Type{<:FeatureCollection}) = true
 trait(fc::FeatureCollection) = FeatureCollectionTrait()
 
-nfeature(::FeatureCollectionTrait, fc::FeatureCollection) =
+nfeature(t::FeatureCollectionTrait, fc::FeatureCollection) =
     _parent_is_fc(fc) ? nfeature(t, parent(fc)) : length(parent(fc))
-getfeature(::FeatureCollectionTrait, fc::FeatureCollection) =
+getfeature(t::FeatureCollectionTrait, fc::FeatureCollection) =
     _parent_is_fc(fc) ? getfeature(t, parent(fc)) : parent(fc)
 getfeature(t::FeatureCollectionTrait, fc::FeatureCollection, i::Integer) =
     _parent_is_fc(fc) ? getfeature(t, parent(fc), i) : parent(fc)[i]


### PR DESCRIPTION
`t` was not defined in these two functions, throwing an error e.g. on calling `GeoJSON.write` on a `Wrappers.FeatureCollection`.