### PR TITLE
Add a convert method for (module, trait, geom)

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -148,7 +148,7 @@ calc_extent(t::AbstractFeatureCollectionTrait, fc) = reduce(Extents.union, filte
 # corresponding geometry type
 function convert(package::Module, geom)
     t = trait(geom)
-    convert(package, trait, geom)
+    convert(package, t, geom)
 end
 function convert(package::Module, trait::AbstractTrait, geom)
     isdefined(package, :geointerface_geomtype) || throw(ArgumentError("$package does not implement `geointerface_geomtype`. Please request this be implemented in a github issue."))

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -150,7 +150,7 @@ function convert(package::Module, geom)
     t = trait(geom)
     convert(package, t, geom)
 end
-function convert(package::Module, trait::AbstractTrait, geom)
+function convert(package::Module, t::AbstractTrait, geom)
     isdefined(package, :geointerface_geomtype) || throw(ArgumentError("$package does not implement `geointerface_geomtype`. Please request this be implemented in a github issue."))
     convert(package.geointerface_geomtype(t), t, geom)
 end

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -148,6 +148,9 @@ calc_extent(t::AbstractFeatureCollectionTrait, fc) = reduce(Extents.union, filte
 # corresponding geometry type
 function convert(package::Module, geom)
     t = trait(geom)
+    convert(package, trait, geom)
+end
+function convert(package::Module, trait::AbstractTrait, geom)
     isdefined(package, :geointerface_geomtype) || throw(ArgumentError("$package does not implement `geointerface_geomtype`. Please request this be implemented in a github issue."))
     convert(package.geointerface_geomtype(t), t, geom)
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -673,6 +673,21 @@ geom type for the trait using the modules `geointerface_traittype` method.
 
 `convert(T::Type)` or `convert(m::Module)` return curried versions of that function, 
 just like `==`.
+
+# Extended help
+
+For developers, the base implementation is `GeoInterface.convert(::YourGeomType, ::AbstractTrait, some_other_geom)`.
+This is the method signature that must be implemented for a custom geometry type.  
+    
+Users may also call this method directly, if they know the exact output - this can sometimes 
+save the Julia compiler some work and cause more optimal code to be generated.
+
+For convenience and type stability there is a `convert(::Module, ::AbstractTrait, geom)` method
+that is particularly useful when the trait of a geometry needs to be propagated deep within the 
+stack.  
+
+This helps to prevent the compiler from losing the trait information, especially useful 
+when dealing with sumtype-like implementations or opaque pointers from C libraries.
 """
 convert(T, geom) = convert(T, geomtrait(geom), geom)
 convert(::Type{T}, x::T) where {T} = x  # no-op


### PR DESCRIPTION
This allows the trait to be passed through completely from the time of discovery to the bottom level, which decreases allocations and dynamic dispatch in long call chains like GeometryOps' `apply`.

If this makes sense to add then I will add tests, docs, etc.